### PR TITLE
BACK-465: Knob.Duration

### DIFF
--- a/src/Scalyr-Java-Client.iml
+++ b/src/Scalyr-Java-Client.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/main" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/main/com/scalyr/api/knobs/DurationKnob.java
+++ b/src/main/com/scalyr/api/knobs/DurationKnob.java
@@ -1,0 +1,4 @@
+package com.scalyr.api.knobs;
+
+public class DurationKnob {
+}


### PR DESCRIPTION
Added a new type of Knob, the Duration knob, which can take a much more flexible entry in the config file (eg "2 minutes" or "3 days" or "45 secs") and then can give you its value in any time unit desired, using functions such as millis(), secs(), minutes(), nanos(), etc.

The constructor takes in (tag name, default value, default value units as a TimeUnits.[...] , filename).

I implemented by first always storing the default passed in value as nanoseconds. Then, when a value is requested in a given format, we parse the config file and if we find the tag, we try and parse its value. If it's in a valid format, we can look up the proper TimeUnit in the hash map and convert to the desired units, and return the Long value. If it's not in a valid format, custom exceptions are raised.

One technicality - other Knobs have a get() method whereas for this Knob we wanted functions such as millis() and nanos(). However I still overrode the get() and getWithTimeout() methods, and these return a java.time.Duration, which can then be combined with its own functions such as .toNanos() to get a Long value.

Also added tests.