### PR TITLE
getInteger()/getLong() SI unit fix (BACK-564)

### DIFF
--- a/src/main/com/scalyr/api/knobs/Knob.java
+++ b/src/main/com/scalyr/api/knobs/Knob.java
@@ -164,14 +164,26 @@ public class Knob {
    * Like {@link #get(java.lang.String, Object, ConfigurationFile[])}, but converts the value to an Integer.
    */
   public static java.lang.Integer getInteger(java.lang.String valueKey, java.lang.Integer defaultValue, ConfigurationFile ... files) {
-    return Converter.toInteger(get(valueKey, defaultValue, files));
+//    Object val = get(valueKey, defaultValue, files);
+//    try {
+//      return Converter.toInteger(val);
+//    } catch (RuntimeException ex) {
+//      return Converter.parseNumberWithSI(val).intValue();
+//    }
+    return (new Knob.Integer(valueKey, defaultValue, files).get());
   }
 
   /**
    * Like {@link #get(java.lang.String, Object, ConfigurationFile[])}, but converts the value to an Long.
    */
   public static java.lang.Long getLong(java.lang.String valueKey, java.lang.Long defaultValue, ConfigurationFile ... files) {
-    return Converter.toLong(get(valueKey, defaultValue, files));
+//    Object val = get(valueKey, defaultValue, files);
+//    try {
+//      return Converter.toLong(val);
+//    } catch (RuntimeException ex) {
+//      return Converter.parseNumberWithSI(val);
+//    }
+    return (new Knob.Long(valueKey, defaultValue, files).get());
   }
 
   /**
@@ -358,9 +370,7 @@ public class Knob {
       super(valueKey, defaultValue, files);
     }
 
-    @Override public java.lang.Integer get() {
-      return convertWithSI(super.get());
-    }
+    @Override public java.lang.Integer get() { return convertWithSI(super.get()); }
 
     @Override public java.lang.Integer getWithTimeout(java.lang.Long timeoutInMs) throws ScalyrDeadlineException {
       return convertWithSI(super.getWithTimeout(timeoutInMs));

--- a/src/main/com/scalyr/api/knobs/Knob.java
+++ b/src/main/com/scalyr/api/knobs/Knob.java
@@ -164,12 +164,6 @@ public class Knob {
    * Like {@link #get(java.lang.String, Object, ConfigurationFile[])}, but converts the value to an Integer.
    */
   public static java.lang.Integer getInteger(java.lang.String valueKey, java.lang.Integer defaultValue, ConfigurationFile ... files) {
-//    Object val = get(valueKey, defaultValue, files);
-//    try {
-//      return Converter.toInteger(val);
-//    } catch (RuntimeException ex) {
-//      return Converter.parseNumberWithSI(val).intValue();
-//    }
     return (new Knob.Integer(valueKey, defaultValue, files).get());
   }
 
@@ -177,12 +171,6 @@ public class Knob {
    * Like {@link #get(java.lang.String, Object, ConfigurationFile[])}, but converts the value to an Long.
    */
   public static java.lang.Long getLong(java.lang.String valueKey, java.lang.Long defaultValue, ConfigurationFile ... files) {
-//    Object val = get(valueKey, defaultValue, files);
-//    try {
-//      return Converter.toLong(val);
-//    } catch (RuntimeException ex) {
-//      return Converter.parseNumberWithSI(val);
-//    }
     return (new Knob.Long(valueKey, defaultValue, files).get());
   }
 

--- a/src/test/com/scalyr/api/tests/KnobTest.java
+++ b/src/test/com/scalyr/api/tests/KnobTest.java
@@ -492,4 +492,15 @@ public class KnobTest extends KnobTestBase {
     Knob.Duration invalidKnob3 = new Knob.Duration("invalidTime3", 3L, TimeUnit.DAYS, paramFile);
     verifyExceptionMessageContains(invalidKnob3::hours, "Invalid duration format: ");
   }
+
+  @Test public void testGetLongGetIntWithSI() {
+    expectRequest(
+            "getFile",
+            "{'token': 'dummyToken', 'path': '/foo.txt'}",
+            "{'status': 'success', 'path': '/foo.txt', 'version': 1, 'createDate': 1000, 'modDate': 2000," +
+                    "'content': '{\\'test\\': \\' 256K\\'}'}");
+    ConfigurationFile paramFile = factory.getFile("/foo.txt");
+    assertEquals((int) Knob.getInteger("test", 1, paramFile), 256000);
+    assertEquals((long) Knob.getLong("test", 1L, paramFile), 256000L);
+  }
 }


### PR DESCRIPTION
fixed getLong()/getInteger() to work with SI Units, and added tests