### PR TITLE
Make Knob.Long and Knob.Integer parse SI values faster.

### DIFF
--- a/src/main/com/scalyr/api/Converter.java
+++ b/src/main/com/scalyr/api/Converter.java
@@ -28,12 +28,12 @@ import java.util.HashMap;
  */
 public class Converter {
   /**
-   * Convert any numeric type to Integer.
+   * Convert any numeric type to Integer. If `parseSI` is set to true, try to parse SI units as well.
    * <p>
    * A null input is returned as-is. Non-numeric inputs trigger an exception. Out-of-range
    * values trigger undefined behavior.
    */
-  public static Integer toInteger(Object value) {
+  public static Integer toInteger(Object value, boolean parseSI) {
     if (value instanceof Integer)
       return (Integer)value;
     else if (value instanceof Long)
@@ -42,8 +42,43 @@ public class Converter {
       return (int)(double)(Double)value;
     else if (value == null)
       return null;
+
+    if (parseSI)
+      return Converter.parseNumberWithSI(value).intValue();
     else
       throw new RuntimeException("Can't convert [" + value + "] to Integer");
+  }
+
+  /**
+   * Convert any numeric type to Integer.
+   * <p>
+   * A null input is returned as-is. Non-numeric inputs trigger an exception. Out-of-range
+   * values trigger undefined behavior.
+   */
+  public static Integer toInteger(Object value) {
+    return toInteger(value, false);
+  }
+
+  /**
+   * Convert any numeric type to Long. If `parseSI` is set to true, try to parse SI units as well.
+   * <p>
+   * A null input is returned as-is. Non-numeric inputs trigger an exception. Out-of-range
+   * values trigger undefined behavior.
+   */
+  public static Long toLong(Object value, boolean parseSI) {
+    if (value instanceof Integer)
+      return (long)(int)(Integer)value;
+    else if (value instanceof Long)
+      return (Long)value;
+    else if (value instanceof Double)
+      return (long)(double)(Double)value;
+    else if (value == null)
+      return null;
+
+    if (parseSI)
+      return Converter.parseNumberWithSI(value);
+    else
+      throw new RuntimeException("Can't convert [" + value + "] to Long");
   }
 
   /**
@@ -53,18 +88,8 @@ public class Converter {
    * values trigger undefined behavior.
    */
   public static Long toLong(Object value) {
-    if (value instanceof Integer)
-      return (long)(int)(Integer)value;
-    else if (value instanceof Long)
-      return (Long)value;
-    else if (value instanceof Double)
-      return (long)(double)(Double)value;
-    else if (value == null)
-      return null;
-    else
-      throw new RuntimeException("Can't convert [" + value + "] to Long");
+    return toLong(value, false);
   }
-
   /**
    * Convert any numeric type to Double.
    * <p>
@@ -124,7 +149,8 @@ public class Converter {
    *  0   1    2     3       4   5   6   7     0
    */
   public static Long parseNumberWithSI(Object valueWithSIObj) {
-    String valueWithSI = toString(valueWithSIObj).trim().toUpperCase();
+    assert valueWithSIObj != null;
+    String valueWithSI = valueWithSIObj.toString();
     long numberPart = 0;
     char multiplier = '\0';
     boolean withI = false;
@@ -153,24 +179,30 @@ public class Converter {
           case 7: break;
           default: throw new RuntimeException(exceptionMessage);
         }
-      } else if (c == 'K' || c == 'M' || c == 'G' || c == 'T' || c == 'P') {
-        switch (state) {
-          case 2:
-          case 3: state = 4; multiplier = c; break;
-          default: throw new RuntimeException(exceptionMessage);
-        }
-      } else if (c == 'I') {
-        switch (state) {
-          case 4: state = 5; withI = true; break;
-          default: throw new RuntimeException(exceptionMessage);
-        }
-      } else if (c == 'B') {
-        switch (state) {
-          case 2:
-          case 3:
-          case 4:
-          case 5: state = 6; break;
-          default: throw new RuntimeException(exceptionMessage);
+      } else if (c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z') {
+        c = c > 'Z' ? (char)(c + 'A' - 'a') : c;
+
+        if  (c == 'K' || c == 'M' || c == 'G' || c == 'T' || c == 'P') {
+          switch (state) {
+            case 2:
+            case 3: state = 4; multiplier = c; break;
+            default: throw new RuntimeException(exceptionMessage);
+          }
+        } else if (c == 'I') {
+          switch (state) {
+            case 4: state = 5; withI = true; break;
+            default: throw new RuntimeException(exceptionMessage);
+          }
+        } else if (c == 'B') {
+          switch (state) {
+            case 2:
+            case 3:
+            case 4:
+            case 5: state = 6; break;
+            default: throw new RuntimeException(exceptionMessage);
+          }
+        } else {
+          throw new RuntimeException(exceptionMessage);
         }
       } else {
         throw new RuntimeException(exceptionMessage);

--- a/src/main/com/scalyr/api/knobs/Knob.java
+++ b/src/main/com/scalyr/api/knobs/Knob.java
@@ -359,23 +359,15 @@ public class Knob {
     }
 
     @Override public java.lang.Integer get() {
-      return convertWithSI(super.get());
+      return Converter.toInteger(super.get(), true);
     }
 
     @Override public java.lang.Integer getWithTimeout(java.lang.Long timeoutInMs) throws ScalyrDeadlineException {
-      return convertWithSI(super.getWithTimeout(timeoutInMs));
+      return Converter.toInteger(super.getWithTimeout(timeoutInMs), true);
     }
 
     @Override public Integer expireHint(java.lang.String dateStr) {
       return this;
-    }
-
-    protected java.lang.Integer convertWithSI(Object obj) {
-      try {
-        return Converter.toInteger(obj);
-      } catch (RuntimeException ex) {
-        return Converter.parseNumberWithSI(obj).intValue();
-      }
     }
   }
 
@@ -388,23 +380,15 @@ public class Knob {
     }
 
     @Override public java.lang.Long get() {
-      return convertWithSI(super.get());
+      return Converter.toLong(super.get(), true);
     }
 
     @Override public java.lang.Long getWithTimeout(java.lang.Long timeoutInMs) throws ScalyrDeadlineException {
-      return convertWithSI(super.getWithTimeout(timeoutInMs));
+      return Converter.toLong(super.getWithTimeout(timeoutInMs), true);
     }
 
     @Override public Long expireHint(java.lang.String dateStr) {
       return this;
-    }
-
-    private java.lang.Long convertWithSI(Object obj) {
-      try {
-        return Converter.toLong(obj);
-      } catch (RuntimeException ex) {
-        return Converter.parseNumberWithSI(obj);
-      }
     }
   }
 
@@ -593,11 +577,11 @@ public class Knob {
     }
 
     @Override public java.lang.Long get() {
-      return convertWithSI(super.get());
+      return Converter.toLong(super.get(), true);
     }
 
     @Override public java.lang.Long getWithTimeout(java.lang.Long timeoutInMs) throws ScalyrDeadlineException {
-      return convertWithSI(super.getWithTimeout(timeoutInMs));
+      return Converter.toLong(super.getWithTimeout(timeoutInMs), true);
     }
 
     @Override public Size expireHint(java.lang.String dateStr) {
@@ -620,13 +604,5 @@ public class Knob {
     public double getTiB() { return this.getB() / Math.pow(2, 40);   } // Tebibyte
     public double getPB()  { return this.getB() / Math.pow(10, 15);  } // Petabyte
     public double getPiB() { return this.getB() / Math.pow(2, 50);   } // Pebibyte
-
-    private java.lang.Long convertWithSI(Object obj) {
-      try {
-        return Converter.toLong(obj);
-      } catch (RuntimeException ex) {
-        return Converter.parseNumberWithSI(obj);
-      }
-    }
   }
 }


### PR DESCRIPTION
* Avoid using the try-catch pattern to fall back to SI parsing, this
  creates an unnecessary exception object and fills its stacktrace.
* Avoid String.trim and Strong.toUpperCase when parsing SI, use simple
  ascii char offset calculation for better speed.

Benchmark result (invoke Knob.getLong 1 million times, with an SI value)
Before: 20 seconds
After:  2 seconds
Without SI value: 2 seconds.