### PR TITLE
API-207 Enable GZIP compression for logs

### DIFF
--- a/src/main/com/scalyr/api/internal/ApacheHttpClient.java
+++ b/src/main/com/scalyr/api/internal/ApacheHttpClient.java
@@ -2,7 +2,6 @@ package com.scalyr.api.internal;
 
 import com.scalyr.api.internal.ScalyrService.RpcOptions;
 import com.scalyr.api.knobs.Knob;
-import jdk.internal.util.xml.impl.Input;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.GzipCompressingEntity;

--- a/src/main/com/scalyr/api/internal/ApacheHttpClient.java
+++ b/src/main/com/scalyr/api/internal/ApacheHttpClient.java
@@ -81,8 +81,12 @@ public class ApacheHttpClient extends AbstractHttpClient {
     if (responseEntity != null) {
       if (responseEncoding != null && responseEncoding.contains("gzip")) {
         responseStream = new GZIPInputStream(responseEntity.getContent());
-      } else responseStream = responseEntity.getContent();
-    } else responseStream = null;
+      } else {
+        responseStream = responseEntity.getContent();
+      }
+    } else {
+        responseStream = null;
+    }
   }
 
   /**

--- a/src/main/com/scalyr/api/internal/ApacheHttpClient.java
+++ b/src/main/com/scalyr/api/internal/ApacheHttpClient.java
@@ -64,8 +64,7 @@ public class ApacheHttpClient extends AbstractHttpClient {
 
     if (contentEncoding != null && contentEncoding.length() > 0)
       request.setHeader("Content-Encoding", contentEncoding);
-      // As of now, we don't need to 'request' compressed responses from Scalyr.
-      // request.setHeader("Accept-Encoding", contentEncoding + ", identity");
+      request.setHeader("Accept-Encoding", contentEncoding + ", identity");
 
     ByteArrayEntity inputEntity = new ByteArrayEntity(requestBody, 0, requestBodyLength);
     inputEntity.setContentType(contentType);
@@ -115,8 +114,8 @@ public class ApacheHttpClient extends AbstractHttpClient {
 
 
   @Override public InputStream getInputStream() throws IOException {
-    // As of now, gzip compression is disabled on Scalyr's responses to the Java client, so no need to check for gzip encoding.
-    // return getResponseEncoding().contains("gzip") ? new GZIPInputStream(responseStream) : responseStream;
+    if (getResponseEncoding() != null && getResponseEncoding().contains("gzip"))
+      return new GZIPInputStream(responseStream);
     return responseStream;
   }
 

--- a/src/main/com/scalyr/api/internal/ApacheHttpClient.java
+++ b/src/main/com/scalyr/api/internal/ApacheHttpClient.java
@@ -76,9 +76,13 @@ public class ApacheHttpClient extends AbstractHttpClient {
     response = httpClient.execute(request);
 
     HttpEntity responseEntity = response.getEntity();
-    responseStream = (responseEntity != null) ? responseEntity.getContent() : null;
     responseContentType = (responseEntity != null && responseEntity.getContentType() != null) ? responseEntity.getContentType().getValue() : null;
     responseEncoding = (responseEntity != null && responseEntity.getContentEncoding() != null) ? responseEntity.getContentEncoding().getValue() : null;
+    if (responseEntity != null) {
+      if (responseEncoding != null && responseEncoding.contains("gzip")) {
+        responseStream = new GZIPInputStream(responseEntity.getContent());
+      } else responseStream = responseEntity.getContent();
+    } else responseStream = null;
   }
 
   /**
@@ -113,9 +117,7 @@ public class ApacheHttpClient extends AbstractHttpClient {
   }
 
 
-  @Override public InputStream getInputStream() throws IOException {
-    if (getResponseEncoding() != null && getResponseEncoding().contains("gzip"))
-      return new GZIPInputStream(responseStream);
+  @Override public InputStream getInputStream() {
     return responseStream;
   }
 

--- a/src/main/com/scalyr/api/internal/ApacheHttpClient.java
+++ b/src/main/com/scalyr/api/internal/ApacheHttpClient.java
@@ -70,11 +70,7 @@ public class ApacheHttpClient extends AbstractHttpClient {
     ByteArrayEntity inputEntity = new ByteArrayEntity(requestBody, 0, requestBodyLength);
     inputEntity.setContentType(contentType);
 
-    if ("gzip".equals(contentEncoding)) {
-      request.setEntity(new GzipCompressingEntity(inputEntity));
-    } else {
-      request.setEntity(inputEntity);
-    }
+    request.setEntity("gzip".equals(contentEncoding) ? new GzipCompressingEntity(inputEntity) : inputEntity);
 
     request.setConfig(configBuilder.build());
 

--- a/src/main/com/scalyr/api/internal/ApacheHttpClient.java
+++ b/src/main/com/scalyr/api/internal/ApacheHttpClient.java
@@ -88,7 +88,7 @@ public class ApacheHttpClient extends AbstractHttpClient {
 
   /**
    * Version of constructor with a Gzip Compression toggle, rather than a freely settable content-encoding.
-   * If enableGzip is true, Content-Type gets set to "application/gzip" and Content-Encoding is null.
+   * If enableGzip is true, Content-Encoding is set to "gzip".
    */
   public ApacheHttpClient(URL url, int requestLength, boolean closeConnections, RpcOptions options,
                           byte[] requestBody, int requestBodyLength, String contentType, boolean enableGzip) throws IOException {

--- a/src/main/com/scalyr/api/internal/JavaNetHttpClient.java
+++ b/src/main/com/scalyr/api/internal/JavaNetHttpClient.java
@@ -31,6 +31,9 @@ public class JavaNetHttpClient extends AbstractHttpClient {
     connection.setConnectTimeout(options.connectionTimeoutMs);
     connection.setReadTimeout(options.readTimeoutMs);
 
+    if ("application/gzip".equals(contentType) || "gzip".equals(contentEncoding))
+      enableGzip = true;
+
     if (closeConnections)
       connection.setRequestProperty("connection", "close");
 
@@ -40,19 +43,19 @@ public class JavaNetHttpClient extends AbstractHttpClient {
 
     if (contentEncoding != null && contentEncoding.length() > 0)
       connection.setRequestProperty("Content-Encoding", contentEncoding);
-      // As of now, we don't need to 'request' compressed responses from Tomcat.
-      // connection.setRequestProperty("Accept-Encoding", contentEncoding + ", identity");
+      // As of now, we don't need to 'request' compressed responses from Scalyr.
+      // connection.setRequestProperty("Accept-Encoding", contentEncoding + "gzip, identity");
 
     connection.setDoOutput(true);
   }
 
   /**
    * Version of constructor with a Gzip Compression toggle, rather than a freely settable content-encoding.
+   * If enableGzip is true, Content-Type gets set to "application/gzip" and Content-Encoding is null.
    */
   public JavaNetHttpClient(URL url, int requestLength, boolean closeConnections, RpcOptions options,
                            String contentType, boolean enableGzip) throws IOException {
-    this(url, requestLength, closeConnections, options, contentType, enableGzip ? "gzip" : null);
-    this.enableGzip = enableGzip;
+    this(url, requestLength, closeConnections, options, enableGzip ? "application/gzip" : contentType, enableGzip ? "gzip" : null);
   }
 
   @Override public OutputStream getOutputStream() throws IOException {
@@ -72,7 +75,7 @@ public class JavaNetHttpClient extends AbstractHttpClient {
   }
 
   @Override public InputStream getInputStream() throws IOException {
-    // As of now, gzip compression is disabled on Tomcat's responses to the Java client, so no need to check for gzip encoding.
+    // As of now, gzip compression is disabled on Scalyr's responses to the Java client, so no need to check for gzip encoding.
     /*responseStream = getResponseEncoding().contains("gzip") ? new GZIPInputStream(connection.getInputStream())
                                                               : connection.getInputStream();*/
     responseStream = connection.getInputStream();

--- a/src/main/com/scalyr/api/internal/JavaNetHttpClient.java
+++ b/src/main/com/scalyr/api/internal/JavaNetHttpClient.java
@@ -7,14 +7,21 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.GZIPInputStream;
 
 /**
  * AbstractHttpClient implementation based on java.net.HttpURLConnection.
+ * Has Gzip compression capability.
  */
 public class JavaNetHttpClient extends AbstractHttpClient {
   private HttpURLConnection connection;
   private InputStream responseStream;
+  private boolean enableGzip = false;
 
+  /**
+   * Version of constructor with desired Content-Encoding passed in.
+   */
   public JavaNetHttpClient(URL url, int requestLength, boolean closeConnections, RpcOptions options,
                            String contentType, String contentEncoding) throws IOException {
     connection = (HttpURLConnection) url.openConnection();
@@ -32,13 +39,24 @@ public class JavaNetHttpClient extends AbstractHttpClient {
     connection.setRequestProperty("errorStatus", "always200");
 
     if (contentEncoding != null && contentEncoding.length() > 0)
-      connection.setRequestProperty("Content-Encoding", "contentEncoding");
+      connection.setRequestProperty("Content-Encoding", contentEncoding);
+      // As of now, we don't need to 'request' compressed responses from Tomcat.
+      // connection.setRequestProperty("Accept-Encoding", contentEncoding + ", identity");
 
     connection.setDoOutput(true);
   }
 
+  /**
+   * Version of constructor with a Gzip Compression toggle, rather than a freely settable content-encoding.
+   */
+  public JavaNetHttpClient(URL url, int requestLength, boolean closeConnections, RpcOptions options,
+                           String contentType, boolean enableGzip) throws IOException {
+    this(url, requestLength, closeConnections, options, contentType, enableGzip ? "gzip" : null);
+    this.enableGzip = enableGzip;
+  }
+
   @Override public OutputStream getOutputStream() throws IOException {
-    return connection.getOutputStream();
+    return enableGzip ? new GZIPOutputStream(connection.getOutputStream()) : connection.getOutputStream();
   }
 
   @Override public int getResponseCode() throws IOException {
@@ -54,6 +72,9 @@ public class JavaNetHttpClient extends AbstractHttpClient {
   }
 
   @Override public InputStream getInputStream() throws IOException {
+    // As of now, gzip compression is disabled on Tomcat's responses to the Java client, so no need to check for gzip encoding.
+    /*responseStream = getResponseEncoding().contains("gzip") ? new GZIPInputStream(connection.getInputStream())
+                                                              : connection.getInputStream();*/
     responseStream = connection.getInputStream();
     return responseStream;
   }

--- a/src/main/com/scalyr/api/internal/JavaNetHttpClient.java
+++ b/src/main/com/scalyr/api/internal/JavaNetHttpClient.java
@@ -42,8 +42,7 @@ public class JavaNetHttpClient extends AbstractHttpClient {
 
     if (contentEncoding != null && contentEncoding.length() > 0)
       connection.setRequestProperty("Content-Encoding", contentEncoding);
-      // As of now, we don't need to 'request' compressed responses from Scalyr.
-      // connection.setRequestProperty("Accept-Encoding", contentEncoding + "gzip, identity");
+      connection.setRequestProperty("Accept-Encoding", contentEncoding + ", identity");
 
     connection.setDoOutput(true);
   }
@@ -74,11 +73,10 @@ public class JavaNetHttpClient extends AbstractHttpClient {
   }
 
   @Override public InputStream getInputStream() throws IOException {
-    // As of now, gzip compression is disabled on Scalyr's responses to the Java client, so no need to check for gzip encoding.
-    /*responseStream = getResponseEncoding().contains("gzip") ? new GZIPInputStream(connection.getInputStream())
-                                                              : connection.getInputStream();*/
-    responseStream = connection.getInputStream();
-    return responseStream;
+    if (responseStream != null) return responseStream;
+    if (getResponseEncoding() != null && getResponseEncoding().contains("gzip"))
+      return responseStream = new GZIPInputStream(connection.getInputStream());
+    return responseStream = connection.getInputStream();
   }
 
   @Override public void finishedReadingResponse() throws IOException {

--- a/src/main/com/scalyr/api/internal/JavaNetHttpClient.java
+++ b/src/main/com/scalyr/api/internal/JavaNetHttpClient.java
@@ -17,7 +17,7 @@ import java.util.zip.GZIPInputStream;
 public class JavaNetHttpClient extends AbstractHttpClient {
   private HttpURLConnection connection;
   private InputStream responseStream;
-  private boolean enableGzip = false;
+  private boolean enableGzip;
 
   /**
    * Version of constructor with desired Content-Encoding passed in.
@@ -31,8 +31,7 @@ public class JavaNetHttpClient extends AbstractHttpClient {
     connection.setConnectTimeout(options.connectionTimeoutMs);
     connection.setReadTimeout(options.readTimeoutMs);
 
-    if ("application/gzip".equals(contentType) || "gzip".equals(contentEncoding))
-      enableGzip = true;
+    enableGzip = "gzip".equals(contentEncoding);
 
     if (closeConnections)
       connection.setRequestProperty("connection", "close");
@@ -51,11 +50,11 @@ public class JavaNetHttpClient extends AbstractHttpClient {
 
   /**
    * Version of constructor with a Gzip Compression toggle, rather than a freely settable content-encoding.
-   * If enableGzip is true, Content-Type gets set to "application/gzip" and Content-Encoding is null.
+   * If enableGzip is true, Content-Encoding is set to "gzip".
    */
   public JavaNetHttpClient(URL url, int requestLength, boolean closeConnections, RpcOptions options,
                            String contentType, boolean enableGzip) throws IOException {
-    this(url, requestLength, closeConnections, options, enableGzip ? "application/gzip" : contentType, enableGzip ? "gzip" : null);
+    this(url, requestLength, closeConnections, options, contentType, enableGzip ? "gzip" : null);
   }
 
   @Override public OutputStream getOutputStream() throws IOException {

--- a/src/main/com/scalyr/api/logs/EventUploader.java
+++ b/src/main/com/scalyr/api/logs/EventUploader.java
@@ -94,6 +94,12 @@ public class EventUploader {
   private String ourHostname;
 
   /**
+   * Used to enable/disable Gzip compression on uploads.
+   * Can be toggled using Events.enableGzip() and Events.disableGzip().
+   */
+  protected static boolean enableGzip;
+
+  /**
    * Random number generator used to avoid having multiple clients all upload events at the exact
    * same time. Synchronize access.
    */
@@ -258,7 +264,7 @@ public class EventUploader {
    * THIS METHOD IS INTENDED FOR INTERNAL USE ONLY.
    */
   public EventUploader(LogService logService, int memoryLimit, String sessionId, boolean autoUpload,
-      EventAttributes serverAttributes, boolean enableMetaMonitoring, boolean reportThreadNames) {
+                       EventAttributes serverAttributes, boolean enableMetaMonitoring, boolean reportThreadNames) {
     this(logService, memoryLimit, sessionId, autoUpload, serverAttributes, enableMetaMonitoring, reportThreadNames, null, null);
   }
 
@@ -270,6 +276,8 @@ public class EventUploader {
   public EventUploader(LogService logService, int memoryLimit, String sessionId, boolean autoUpload,
       EventAttributes serverAttributes, boolean enableMetaMonitoring, boolean reportThreadNames,
       Timer sharedTimer_, Executor uploadExecutor_) {
+    this.enableGzip = Events.ENABLE_GZIP_BY_DEFAULT; // Toggle gzip compression to default value
+
     this.logService = logService;
     this.autoUpload = autoUpload;
     this.reportThreadNames = reportThreadNames;
@@ -543,7 +551,7 @@ public class EventUploader {
       lastUploadStartMs = ScalyrUtil.currentTimeMillis();
       JSONObject rawResponse;
       try {
-        rawResponse = logService.uploadEvents(sessionId, sessionInfo, eventsToUpload, threadInfos);
+        rawResponse = logService.uploadEvents(sessionId, sessionInfo, eventsToUpload, threadInfos, enableGzip);
       } catch (RuntimeException ex) {
         logUploadFailure(ex.toString());
         throw ex;

--- a/src/main/com/scalyr/api/logs/EventUploader.java
+++ b/src/main/com/scalyr/api/logs/EventUploader.java
@@ -97,7 +97,7 @@ public class EventUploader {
    * Used to enable/disable Gzip compression on uploads.
    * Can be toggled using Events.enableGzip() and Events.disableGzip().
    */
-  protected static boolean enableGzip;
+  protected static boolean enableGzip = Events.ENABLE_GZIP_BY_DEFAULT;
 
   /**
    * Random number generator used to avoid having multiple clients all upload events at the exact
@@ -276,20 +276,16 @@ public class EventUploader {
   public EventUploader(LogService logService, int memoryLimit, String sessionId, boolean autoUpload,
       EventAttributes serverAttributes, boolean enableMetaMonitoring, boolean reportThreadNames,
       Timer sharedTimer_, Executor uploadExecutor_) {
-    this.enableGzip = Events.ENABLE_GZIP_BY_DEFAULT; // Toggle gzip compression to default value
-
-    this.logService = logService;
-    this.autoUpload = autoUpload;
-    this.reportThreadNames = reportThreadNames;
-
-    this.memoryLimit = memoryLimit;
-    pendingEventBuffer = new CircularByteArray(memoryLimit);
-
-    this.sessionId = sessionId;
-    this.serverAttributes = serverAttributes;
+    this.logService           = logService;
+    this.autoUpload           = autoUpload;
+    this.reportThreadNames    = reportThreadNames;
+    this.memoryLimit          = memoryLimit;
+    this.pendingEventBuffer   = new CircularByteArray(memoryLimit);
+    this.sessionId            = sessionId;
+    this.serverAttributes     = serverAttributes;
     this.enableMetaMonitoring = enableMetaMonitoring;
+    this.uploadExecutor       = uploadExecutor_;
 
-    this.uploadExecutor = uploadExecutor_;
     launchUploadTimer(sharedTimer_);
 
     // To aid customers being able to quickly see the results of events being uploaded

--- a/src/main/com/scalyr/api/logs/Events.java
+++ b/src/main/com/scalyr/api/logs/Events.java
@@ -115,6 +115,9 @@ public class Events {
    */
   public static void enableGzip() {
     EventUploader instance = uploaderInstance.get();
+    if (instance == null)
+      throw new RuntimeException("Call Events.init() before this method");
+    
     instance.enableGzip = true;
   }
 
@@ -123,6 +126,9 @@ public class Events {
    */
   public static void disableGzip() {
     EventUploader instance = uploaderInstance.get();
+    if (instance == null)
+      throw new RuntimeException("Call Events.init() before this method");
+
     instance.enableGzip = false;
   }
 

--- a/src/main/com/scalyr/api/logs/Events.java
+++ b/src/main/com/scalyr/api/logs/Events.java
@@ -31,9 +31,8 @@ public class Events {
 
   /**
    * Whether to enable gzip compression on uploads by default.
-   * TODO: Decide whether to enable or not.
    */
-  public final static boolean ENABLE_GZIP_BY_DEFAULT = false;
+  public final static boolean ENABLE_GZIP_BY_DEFAULT = true;
 
   /**
    * The most recent value passed to setEventFilter. We store this here, in addition to in the
@@ -494,5 +493,6 @@ public class Events {
     EventUploader instance = new EventUploader(logService, memoryLimit, artificialSessionId, autoUpload, null, true, reportThreadNames);
     uploaderInstance.set(instance);
     instance.eventFilter = eventFilter;
+    instance.enableGzip = Events.ENABLE_GZIP_BY_DEFAULT;
   }
 }

--- a/src/main/com/scalyr/api/logs/Events.java
+++ b/src/main/com/scalyr/api/logs/Events.java
@@ -116,8 +116,8 @@ public class Events {
   public static void enableGzip() {
     EventUploader instance = uploaderInstance.get();
     if (instance == null)
-      throw new RuntimeException("Call Events.init() before this method");
-    
+      throw new RuntimeException("Call Events.init() before Events.enableGzip()");
+
     instance.enableGzip = true;
   }
 
@@ -127,7 +127,7 @@ public class Events {
   public static void disableGzip() {
     EventUploader instance = uploaderInstance.get();
     if (instance == null)
-      throw new RuntimeException("Call Events.init() before this method");
+      throw new RuntimeException("Call Events.init() before Events.disableGzip()");
 
     instance.enableGzip = false;
   }
@@ -140,7 +140,7 @@ public class Events {
   public static void setCloseConnections(boolean value) {
     EventUploader instance = uploaderInstance.get();
     if (instance == null)
-      throw new RuntimeException("Call Events.init() before this method");
+      throw new RuntimeException("Call Events.init() before Events.setCloseConnections()");
 
     instance.logService.closeConnections = value;
   }
@@ -160,7 +160,7 @@ public class Events {
   public static void setExplicitlyDisconnect(boolean value) {
     EventUploader instance = uploaderInstance.get();
     if (instance == null)
-      throw new RuntimeException("Call Events.init() before this method");
+      throw new RuntimeException("Call Events.init() before Events.setExplicitlyDisconnect()");
 
     instance.logService.explicitlyDisconnect = value;
   }

--- a/src/main/com/scalyr/api/logs/Events.java
+++ b/src/main/com/scalyr/api/logs/Events.java
@@ -30,6 +30,12 @@ public class Events {
   private static AtomicReference<EventUploader> uploaderInstance = new AtomicReference<EventUploader>();
 
   /**
+   * Whether to enable gzip compression on uploads by default.
+   * TODO: Decide whether to enable or not.
+   */
+  public final static boolean ENABLE_GZIP_BY_DEFAULT = false;
+
+  /**
    * The most recent value passed to setEventFilter. We store this here, in addition to in the
    * EventUploader, in case setEventFilter is called before init().
    */
@@ -103,6 +109,22 @@ public class Events {
     instance.eventFilter = eventFilter;
 
     uploaderInstance.set(instance);
+  }
+
+  /**
+   * Enable Gzip compression in the uploader.
+   */
+  public static void enableGzip() {
+    EventUploader instance = uploaderInstance.get();
+    instance.enableGzip = true;
+  }
+
+  /**
+   * Disable Gzip compression in the uploader.
+   */
+  public static void disableGzip() {
+    EventUploader instance = uploaderInstance.get();
+    instance.enableGzip = false;
   }
 
   /**

--- a/src/main/com/scalyr/api/logs/LogService.java
+++ b/src/main/com/scalyr/api/logs/LogService.java
@@ -54,6 +54,7 @@ public class LogService extends ScalyrService {
    *     all calls to uploadEvents with a given session ID.
    * @param events The events to upload (a JSON array).
    * @param threadInfos Optional; contains information for the threads referenced in the events array.
+   * @param enableGzip Optional; enable gzip compression on the upload.
    *
    * @return The JSON-formatted response from the server. See <a href='https://www.scalyr.com/help/api'>scalyr.com/help/api</a>.
    *
@@ -61,7 +62,7 @@ public class LogService extends ScalyrService {
    * @throws ScalyrNetworkException
    */
   public JSONObject uploadEvents(String sessionId, JSONObject sessionInfo,
-      JSONStreamAware events, JSONArray threadInfos)
+      JSONStreamAware events, JSONArray threadInfos, boolean enableGzip)
       throws ScalyrException, ScalyrNetworkException {
     JSONObject parameters = new JSONObject();
 
@@ -74,7 +75,15 @@ public class LogService extends ScalyrService {
     if (threadInfos != null && threadInfos.size() > 0)
       parameters.put("threads", threadInfos);
 
-    return invokeApi("addEvents", parameters);
+    return invokeApi("addEvents", parameters, enableGzip);
+  }
+
+  /**
+   * uploadEvents() wrapper with enableGzip set to default value.
+   */
+  public JSONObject uploadEvents(String sessionId, JSONObject sessionInfo,
+                                 JSONStreamAware events, JSONArray threadInfos) {
+    return uploadEvents(sessionId, sessionInfo, events, threadInfos, Events.ENABLE_GZIP_BY_DEFAULT);
   }
 
   public static final int SPAN_TYPE_LEAF  = 0;

--- a/src/test/com/scalyr/api/tests/GzipTest.java
+++ b/src/test/com/scalyr/api/tests/GzipTest.java
@@ -19,27 +19,23 @@ import static org.junit.Assert.assertFalse;
  * or a remote Scalyr environment. You must manually check that the test logs are received and decompressed
  * correctly at the destination.
  */
-public class GzipTest extends LogsTestBase {
-  @Test @Ignore
-  public void testGzipOnJavaNetHttpClient() {
+@Ignore public class GzipTest extends LogsTestBase {
+
+  @Test public void testGzipOnJavaNetHttpClient() {
     // Put appropriate log write token into LogService()
     LogService testService = new LogService("0rXw/66WWhDPKouk0rZDkePU7D6bWpoQTOGYFxH/K1yc-");
     // Either put localhost here, or a particular Scalyr environment.
     testService = testService.setServerAddress("http://localhost:8080");
 
     Events._reset("testGzipSession", testService, 999999, false, true);
-
     // Enable Gzip if not enabled by default
     if (!Events.ENABLE_GZIP_BY_DEFAULT) Events.enableGzip();
 
     Events.info(new EventAttributes("tag", "testWithGzipJava", "foo1", "bla1", "foo2", "bla2"));
-
     Events.flush();
-
   }
 
-  @Test @Ignore
-  public void testGzipOnApacheHttpClient() {
+  @Test public void testGzipOnApacheHttpClient() {
     Knob.setDefaultFiles(new ConfigurationFile[0]);
 
     // Put appropriate log write token into LogService()
@@ -48,7 +44,6 @@ public class GzipTest extends LogsTestBase {
     testService = testService.setServerAddress("http://localhost:8080");
 
     Events._reset("testGzipSession", testService, 999999, false, true);
-
     // Enable Gzip if not enabled by default
     if (!Events.ENABLE_GZIP_BY_DEFAULT) Events.enableGzip();
 
@@ -56,10 +51,8 @@ public class GzipTest extends LogsTestBase {
     TuningConstants.useApacheHttpClientForEventUploader = new Knob.Boolean("foo", true);
 
     Events.info(new EventAttributes("tag", "testWithGzipApache", "foo1", "bla1", "foo2", "bla2"));
-
     Events.flush();
 
     TuningConstants.useApacheHttpClientForEventUploader = null; // Set it back to original value of null
-
   }
 }

--- a/src/test/com/scalyr/api/tests/GzipTest.java
+++ b/src/test/com/scalyr/api/tests/GzipTest.java
@@ -1,6 +1,7 @@
 package com.scalyr.api.tests;
 
 import com.scalyr.api.TuningConstants;
+import com.scalyr.api.knobs.ConfigurationFile;
 import com.scalyr.api.knobs.Knob;
 import com.scalyr.api.logs.EventAttributes;
 import com.scalyr.api.logs.Events;
@@ -8,16 +9,22 @@ import com.scalyr.api.logs.LogService;
 
 
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 /**
- * Tests for Gzip compression.
+ * Tests for Gzip compression. These are marked as @Ignore b/c they are dependent on a local server instance
+ * or a remote Scalyr environment. You must manually check that the test logs are received and decompressed
+ * correctly at the destination.
  */
 public class GzipTest extends LogsTestBase {
-  @Test public void testGzipOnJavaNetHttpClient() {
+  @Test @Ignore
+  public void testGzipOnJavaNetHttpClient() {
+    // Put appropriate log write token into LogService()
     LogService testService = new LogService("0rXw/66WWhDPKouk0rZDkePU7D6bWpoQTOGYFxH/K1yc-");
+    // Either put localhost here, or a particular Scalyr environment.
     testService = testService.setServerAddress("http://localhost:8080");
 
     Events._reset("testGzipSession", testService, 999999, false, true);
@@ -25,14 +32,19 @@ public class GzipTest extends LogsTestBase {
     // Enable Gzip if not enabled by default
     if (!Events.ENABLE_GZIP_BY_DEFAULT) Events.enableGzip();
 
-    Events.info(new EventAttributes("tag", "testWithGzipJava"));
+    Events.info(new EventAttributes("tag", "testWithGzipJava", "foo1", "bla1", "foo2", "bla2"));
 
     Events.flush();
 
   }
 
-  @Test public void testGzipOnApacheHttpClient() {
+  @Test @Ignore
+  public void testGzipOnApacheHttpClient() {
+    Knob.setDefaultFiles(new ConfigurationFile[0]);
+
+    // Put appropriate log write token into LogService()
     LogService testService = new LogService("0rXw/66WWhDPKouk0rZDkePU7D6bWpoQTOGYFxH/K1yc-");
+    // Either put localhost here, or a particular Scalyr environment.
     testService = testService.setServerAddress("http://localhost:8080");
 
     Events._reset("testGzipSession", testService, 999999, false, true);
@@ -43,7 +55,7 @@ public class GzipTest extends LogsTestBase {
     // Turn on usage of ApacheHTTPClient
     TuningConstants.useApacheHttpClientForEventUploader = new Knob.Boolean("foo", true);
 
-    Events.info(new EventAttributes("tag", "testWithGzipApache"));
+    Events.info(new EventAttributes("tag", "testWithGzipApache", "foo1", "bla1", "foo2", "bla2"));
 
     Events.flush();
 

--- a/src/test/com/scalyr/api/tests/GzipTest.java
+++ b/src/test/com/scalyr/api/tests/GzipTest.java
@@ -21,13 +21,14 @@ import static org.junit.Assert.assertFalse;
  */
 @Ignore public class GzipTest extends LogsTestBase {
 
+  // Put appropriate log write token here.
   String apiLogWriteKey = "0erYhZEXU0F0Apu1FKm6LAu7UOn/2ULSGOTri64i1WBU-";
+
+  // Either put localhost here, or a particular Scalyr environment.
   String serverAddress = "http://qatesting.scalyr.com";
 
   @Test public void testGzipOnJavaNetHttpClient() {
-    // Put appropriate log write token into LogService()
     LogService testService = new LogService(apiLogWriteKey);
-    // Either put localhost here, or a particular Scalyr environment.
     testService = testService.setServerAddress(serverAddress);
 
     Events._reset("testGzipSession", testService, 999999, false, true);
@@ -41,9 +42,7 @@ import static org.junit.Assert.assertFalse;
   @Test public void testGzipOnApacheHttpClient() {
     Knob.setDefaultFiles(new ConfigurationFile[0]);
 
-    // Put appropriate log write token into LogService()
     LogService testService = new LogService(apiLogWriteKey);
-    // Either put localhost here, or a particular Scalyr environment.
     testService = testService.setServerAddress(serverAddress);
 
     Events._reset("testGzipSession", testService, 999999, false, true);

--- a/src/test/com/scalyr/api/tests/GzipTest.java
+++ b/src/test/com/scalyr/api/tests/GzipTest.java
@@ -22,10 +22,10 @@ import static org.junit.Assert.assertFalse;
 @Ignore public class GzipTest extends LogsTestBase {
 
   // Put appropriate log write token here.
-  String apiLogWriteKey = "0erYhZEXU0F0Apu1FKm6LAu7UOn/2ULSGOTri64i1WBU-";
+  String apiLogWriteKey = "";
 
-  // Either put localhost here, or a particular Scalyr environment.
-  String serverAddress = "http://qatesting.scalyr.com";
+  // Either put localhost here, or a particular Scalyr environment. Remember to use "https" for staging and prod.
+  String serverAddress = "https://scalyr.com";
 
   @Test public void testGzipOnJavaNetHttpClient() {
     LogService testService = new LogService(apiLogWriteKey);

--- a/src/test/com/scalyr/api/tests/GzipTest.java
+++ b/src/test/com/scalyr/api/tests/GzipTest.java
@@ -1,0 +1,53 @@
+package com.scalyr.api.tests;
+
+import com.scalyr.api.TuningConstants;
+import com.scalyr.api.knobs.Knob;
+import com.scalyr.api.logs.EventAttributes;
+import com.scalyr.api.logs.Events;
+import com.scalyr.api.logs.LogService;
+
+
+import org.junit.After;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests for Gzip compression.
+ */
+public class GzipTest extends LogsTestBase {
+  @Test public void testGzipOnJavaNetHttpClient() {
+    LogService testService = new LogService("0rXw/66WWhDPKouk0rZDkePU7D6bWpoQTOGYFxH/K1yc-");
+    testService = testService.setServerAddress("http://localhost:8080");
+
+    Events._reset("testGzipSession", testService, 999999, false, true);
+
+    // Enable Gzip if not enabled by default
+    if (!Events.ENABLE_GZIP_BY_DEFAULT) Events.enableGzip();
+
+    Events.info(new EventAttributes("tag", "testWithGzipJava"));
+
+    Events.flush();
+
+  }
+
+  @Test public void testGzipOnApacheHttpClient() {
+    LogService testService = new LogService("0rXw/66WWhDPKouk0rZDkePU7D6bWpoQTOGYFxH/K1yc-");
+    testService = testService.setServerAddress("http://localhost:8080");
+
+    Events._reset("testGzipSession", testService, 999999, false, true);
+
+    // Enable Gzip if not enabled by default
+    if (!Events.ENABLE_GZIP_BY_DEFAULT) Events.enableGzip();
+
+    // Turn on usage of ApacheHTTPClient
+    TuningConstants.useApacheHttpClientForEventUploader = new Knob.Boolean("foo", true);
+
+    Events.info(new EventAttributes("tag", "testWithGzipApache"));
+
+    Events.flush();
+
+    TuningConstants.useApacheHttpClientForEventUploader = null; // Set it back to original value of null
+
+  }
+}

--- a/src/test/com/scalyr/api/tests/GzipTest.java
+++ b/src/test/com/scalyr/api/tests/GzipTest.java
@@ -21,15 +21,18 @@ import static org.junit.Assert.assertFalse;
  */
 @Ignore public class GzipTest extends LogsTestBase {
 
+  String apiLogWriteKey = "0erYhZEXU0F0Apu1FKm6LAu7UOn/2ULSGOTri64i1WBU-";
+  String serverAddress = "http://qatesting.scalyr.com";
+
   @Test public void testGzipOnJavaNetHttpClient() {
     // Put appropriate log write token into LogService()
-    LogService testService = new LogService("0rXw/66WWhDPKouk0rZDkePU7D6bWpoQTOGYFxH/K1yc-");
+    LogService testService = new LogService(apiLogWriteKey);
     // Either put localhost here, or a particular Scalyr environment.
-    testService = testService.setServerAddress("http://localhost:8080");
+    testService = testService.setServerAddress(serverAddress);
 
     Events._reset("testGzipSession", testService, 999999, false, true);
-    // Enable Gzip if not enabled by default
-    if (!Events.ENABLE_GZIP_BY_DEFAULT) Events.enableGzip();
+    // Enable Gzip in case it's not enabled by default
+    Events.enableGzip();
 
     Events.info(new EventAttributes("tag", "testWithGzipJava", "foo1", "bla1", "foo2", "bla2"));
     Events.flush();
@@ -39,13 +42,13 @@ import static org.junit.Assert.assertFalse;
     Knob.setDefaultFiles(new ConfigurationFile[0]);
 
     // Put appropriate log write token into LogService()
-    LogService testService = new LogService("0rXw/66WWhDPKouk0rZDkePU7D6bWpoQTOGYFxH/K1yc-");
+    LogService testService = new LogService(apiLogWriteKey);
     // Either put localhost here, or a particular Scalyr environment.
-    testService = testService.setServerAddress("http://localhost:8080");
+    testService = testService.setServerAddress(serverAddress);
 
     Events._reset("testGzipSession", testService, 999999, false, true);
-    // Enable Gzip if not enabled by default
-    if (!Events.ENABLE_GZIP_BY_DEFAULT) Events.enableGzip();
+    // Enable Gzip in case it's not enabled by default
+    Events.enableGzip();
 
     // Turn on usage of ApacheHTTPClient
     TuningConstants.useApacheHttpClientForEventUploader = new Knob.Boolean("foo", true);

--- a/src/test/com/scalyr/api/tests/LogsTestBase.java
+++ b/src/test/com/scalyr/api/tests/LogsTestBase.java
@@ -47,5 +47,9 @@ public class LogsTestBase extends ScalyrApiTestBase {
     @Override public JSONObject invokeApi(String methodName, JSONObject parameters) {
       return mockServer.invokeApi(methodName, parameters);
     }
+
+    @Override public JSONObject invokeApi(String methodName, JSONObject parameters, boolean enableGzip) {
+      return mockServer.invokeApi(methodName, parameters);
+    }
   }
 }


### PR DESCRIPTION
Enables gzip compression by default in the client. Can now be toggled on/off with `Events.enableGzip()` and `Events.disableGzip()`.

**Don't merge this until commit** `a4e8f73` **makes it onto** `prod`