### PR TITLE
Changed long/double to Long/Double for Size/Duration Knobs

### DIFF
--- a/src/main/com/scalyr/api/knobs/Knob.java
+++ b/src/main/com/scalyr/api/knobs/Knob.java
@@ -538,19 +538,18 @@ public class Knob {
     // New Methods
     //--------------------------------------------------------------------------------
 
-    public long nanos()   { return (long) super.getWithTimeout(null, false); }
+    public java.lang.Long nanos()   { return convertOrNull(TimeUnit.NANOSECONDS);  }
+    public java.lang.Long micros()  { return convertOrNull(TimeUnit.MICROSECONDS); }
+    public java.lang.Long millis()  { return convertOrNull(TimeUnit.MILLISECONDS); }
+    public java.lang.Long seconds() { return convertOrNull(TimeUnit.SECONDS);      }
+    public java.lang.Long minutes() { return convertOrNull(TimeUnit.MINUTES);      }
+    public java.lang.Long hours()   { return convertOrNull(TimeUnit.HOURS);        }
+    public java.lang.Long days()    { return convertOrNull(TimeUnit.DAYS);         }
 
-    public long micros()  { return TimeUnit.MICROSECONDS.convert(nanos(), TimeUnit.NANOSECONDS); }
-
-    public long millis()  { return TimeUnit.MILLISECONDS.convert(nanos(), TimeUnit.NANOSECONDS); }
-
-    public long seconds() { return TimeUnit.SECONDS.convert(nanos(),      TimeUnit.NANOSECONDS); }
-
-    public long minutes() { return TimeUnit.MINUTES.convert(nanos(),      TimeUnit.NANOSECONDS); }
-
-    public long hours()   { return TimeUnit.HOURS.convert(nanos(),        TimeUnit.NANOSECONDS); }
-
-    public long days()    { return TimeUnit.DAYS.convert(nanos(),         TimeUnit.NANOSECONDS); }
+    private java.lang.Long convertOrNull(TimeUnit desiredUnits) {
+      java.lang.Long value = (java.lang.Long) super.getWithTimeout(null, false);
+      return value != null ? desiredUnits.convert(value, TimeUnit.NANOSECONDS) : null;
+    }
   }
 
   /**
@@ -585,16 +584,21 @@ public class Knob {
     // Returns are doubles (for cases such as calling getKB() on '500B', which will yield a decimal).
     //-----------------------------------------------------------------------------------------------
 
-    public double getB()   { return this.get().doubleValue();        } // Byte
-    public double getKB()  { return this.getB() / 1000D;             } // Kilobyte
-    public double getKiB() { return this.getB() / 1024D;             } // Kibibyte
-    public double getMB()  { return this.getB() / Math.pow(10, 6);   } // Megabyte
-    public double getMiB() { return this.getB() / Math.pow(2, 20);   } // Mebibyte
-    public double getGB()  { return this.getB() / Math.pow(10, 9);   } // Gigabyte
-    public double getGiB() { return this.getB() / Math.pow(2, 30);   } // Gibibyte
-    public double getTB()  { return this.getB() / Math.pow(10, 12);  } // Terabyte
-    public double getTiB() { return this.getB() / Math.pow(2, 40);   } // Tebibyte
-    public double getPB()  { return this.getB() / Math.pow(10, 15);  } // Petabyte
-    public double getPiB() { return this.getB() / Math.pow(2, 50);   } // Pebibyte
+    public java.lang.Double getB()   { return divideOrNull(1D);                } // Byte
+    public java.lang.Double getKB()  { return divideOrNull(1000D);             } // Kilobyte
+    public java.lang.Double getKiB() { return divideOrNull(1024D);             } // Kibibyte
+    public java.lang.Double getMB()  { return divideOrNull(Math.pow(10, 6));   } // Megabyte
+    public java.lang.Double getMiB() { return divideOrNull(Math.pow(2, 20));   } // Mebibyte
+    public java.lang.Double getGB()  { return divideOrNull(Math.pow(10, 9));   } // Gigabyte
+    public java.lang.Double getGiB() { return divideOrNull(Math.pow(2, 30));   } // Gibibyte
+    public java.lang.Double getTB()  { return divideOrNull(Math.pow(10, 12));  } // Terabyte
+    public java.lang.Double getTiB() { return divideOrNull(Math.pow(2, 40));   } // Tebibyte
+    public java.lang.Double getPB()  { return divideOrNull(Math.pow(10, 15));  } // Petabyte
+    public java.lang.Double getPiB() { return divideOrNull(Math.pow(2, 50));   } // Pebibyte
+
+    private java.lang.Double divideOrNull(java.lang.Double divideBy) {
+      java.lang.Long value = get();
+      return value != null ? value.doubleValue() / divideBy : null;
+    }
   }
 }

--- a/src/main/com/scalyr/api/knobs/Knob.java
+++ b/src/main/com/scalyr/api/knobs/Knob.java
@@ -584,19 +584,19 @@ public class Knob {
     // Returns are doubles (for cases such as calling getKB() on '500B', which will yield a decimal).
     //-----------------------------------------------------------------------------------------------
 
-    public java.lang.Double getB()   { return divideOrNull(1D);                } // Byte
-    public java.lang.Double getKB()  { return divideOrNull(1000D);             } // Kilobyte
-    public java.lang.Double getKiB() { return divideOrNull(1024D);             } // Kibibyte
-    public java.lang.Double getMB()  { return divideOrNull(Math.pow(10, 6));   } // Megabyte
-    public java.lang.Double getMiB() { return divideOrNull(Math.pow(2, 20));   } // Mebibyte
-    public java.lang.Double getGB()  { return divideOrNull(Math.pow(10, 9));   } // Gigabyte
-    public java.lang.Double getGiB() { return divideOrNull(Math.pow(2, 30));   } // Gibibyte
-    public java.lang.Double getTB()  { return divideOrNull(Math.pow(10, 12));  } // Terabyte
-    public java.lang.Double getTiB() { return divideOrNull(Math.pow(2, 40));   } // Tebibyte
-    public java.lang.Double getPB()  { return divideOrNull(Math.pow(10, 15));  } // Petabyte
-    public java.lang.Double getPiB() { return divideOrNull(Math.pow(2, 50));   } // Pebibyte
+    public java.lang.Double getB()   { return convertOrNull(1D);                } // Byte
+    public java.lang.Double getKB()  { return convertOrNull(1000D);             } // Kilobyte
+    public java.lang.Double getKiB() { return convertOrNull(1024D);             } // Kibibyte
+    public java.lang.Double getMB()  { return convertOrNull(Math.pow(10, 6));   } // Megabyte
+    public java.lang.Double getMiB() { return convertOrNull(Math.pow(2, 20));   } // Mebibyte
+    public java.lang.Double getGB()  { return convertOrNull(Math.pow(10, 9));   } // Gigabyte
+    public java.lang.Double getGiB() { return convertOrNull(Math.pow(2, 30));   } // Gibibyte
+    public java.lang.Double getTB()  { return convertOrNull(Math.pow(10, 12));  } // Terabyte
+    public java.lang.Double getTiB() { return convertOrNull(Math.pow(2, 40));   } // Tebibyte
+    public java.lang.Double getPB()  { return convertOrNull(Math.pow(10, 15));  } // Petabyte
+    public java.lang.Double getPiB() { return convertOrNull(Math.pow(2, 50));   } // Pebibyte
 
-    private java.lang.Double divideOrNull(java.lang.Double divideBy) {
+    private java.lang.Double convertOrNull(double divideBy) {
       java.lang.Long value = get();
       return value != null ? value.doubleValue() / divideBy : null;
     }

--- a/src/test/com/scalyr/api/tests/KnobTest.java
+++ b/src/test/com/scalyr/api/tests/KnobTest.java
@@ -562,21 +562,21 @@ public class KnobTest extends KnobTestBase {
 
     Knob.Duration value2min = new Knob.Duration("time1", 1L, TimeUnit.SECONDS, paramFile);
 
-    assertEquals(120000L,       value2min.millis());
-    assertEquals(120L,          value2min.seconds());
+    assertEquals((Long) 120000L,       value2min.millis());
+    assertEquals((Long) 120L,          value2min.seconds());
     assertEquals(120000000000L, value2min.get().toNanos());
 
     //ALL possible tests on 3day knob
 
     Knob.Duration value3days = new Knob.Duration("time3", 3L, TimeUnit.DAYS, paramFile);
 
-    assertEquals(259200000000L,       value3days.micros());
-    assertEquals(259200L,             value3days.seconds());
-    assertEquals(259200000000000L,    value3days.nanos());
-    assertEquals(259200000L,          value3days.millis());
-    assertEquals(4320L,               value3days.minutes());
-    assertEquals(72L,                 value3days.hours());
-    assertEquals(3L,                  value3days.days());
+    assertEquals((Long) 259200000000L,       value3days.micros());
+    assertEquals((Long) 259200L,             value3days.seconds());
+    assertEquals((Long) 259200000000000L,    value3days.nanos());
+    assertEquals((Long) 259200000L,          value3days.millis());
+    assertEquals((Long) 4320L,               value3days.minutes());
+    assertEquals((Long) 72L,                 value3days.hours());
+    assertEquals((Long) 3L,                  value3days.days());
     assertEquals(259200000000000L,    value3days.get().toNanos());
     assertEquals(259200000L,          value3days.get().toMillis());
     assertEquals(4320L,               value3days.get().toMinutes());
@@ -586,7 +586,7 @@ public class KnobTest extends KnobTestBase {
     //Testing default value on knob with no config
 
     Knob.Duration unconfiguredKnob = new Knob.Duration("nonexistent label", 1L, TimeUnit.DAYS, paramFile);
-    assertEquals(24L, unconfiguredKnob.hours());
+    assertEquals((Long) 24L, unconfiguredKnob.hours());
     assertEquals(1L, unconfiguredKnob.get().toDays());
 
     //Exception testing


### PR DESCRIPTION
Allows for null default values without a NPE on the unit-denominated `get()` methods.