### PR TITLE
Allow negatives in duration knobs

### DIFF
--- a/src/main/com/scalyr/api/Converter.java
+++ b/src/main/com/scalyr/api/Converter.java
@@ -241,7 +241,7 @@ public class Converter {
     short state = 0;
     char c;
     boolean seenNumber = false;
-    boolean negative = false;
+    boolean seenSign = false;
     String magnitude = "";
     String units = "";
     final String exceptionMessage = "Invalid duration format: \"" + input + "\"";
@@ -251,9 +251,9 @@ public class Converter {
       c = input.charAt(i);
       switch (state) {
         case 0: // Trying to parse number
-          if (c == '-') {
-            if (seenNumber) throw new RuntimeException(exceptionMessage);
-            else negative = true;
+          if (c == '-' || c == '+') {
+            if (seenNumber || seenSign) throw new RuntimeException(exceptionMessage);
+            seenSign = true;
           } else if (Character.isDigit(c)) {
             seenNumber = true;
           } else if (!seenNumber) { // If we've hit a non-# character before getting any numbers
@@ -279,7 +279,7 @@ public class Converter {
 
     // If no units were in the string, we interpret it as nanoseconds. Otherwise get and apply conversion from map.
     return TimeUnit.NANOSECONDS.convert(java.lang.Long.parseLong(magnitude),
-              units.length() == 0 ? TimeUnit.NANOSECONDS : timeUnitMap.get(units));// * (negative ? -1L : 1L);
+              units.length() == 0 ? TimeUnit.NANOSECONDS : timeUnitMap.get(units));
   }
 
   private static final Map<java.lang.String, TimeUnit> timeUnitMap = new HashMap<java.lang.String, TimeUnit>(){{

--- a/src/main/com/scalyr/api/Converter.java
+++ b/src/main/com/scalyr/api/Converter.java
@@ -241,6 +241,7 @@ public class Converter {
     short state = 0;
     char c;
     boolean seenNumber = false;
+    boolean negative = false;
     String magnitude = "";
     String units = "";
     final String exceptionMessage = "Invalid duration format: \"" + input + "\"";
@@ -250,7 +251,10 @@ public class Converter {
       c = input.charAt(i);
       switch (state) {
         case 0: // Trying to parse number
-          if (Character.isDigit(c)) {
+          if (c == '-') {
+            if (seenNumber) throw new RuntimeException(exceptionMessage);
+            else negative = true;
+          } else if (Character.isDigit(c)) {
             seenNumber = true;
           } else if (!seenNumber) { // If we've hit a non-# character before getting any numbers
             throw new RuntimeException(exceptionMessage);
@@ -275,7 +279,7 @@ public class Converter {
 
     // If no units were in the string, we interpret it as nanoseconds. Otherwise get and apply conversion from map.
     return TimeUnit.NANOSECONDS.convert(java.lang.Long.parseLong(magnitude),
-              units.length() == 0 ? TimeUnit.NANOSECONDS : timeUnitMap.get(units));
+              units.length() == 0 ? TimeUnit.NANOSECONDS : timeUnitMap.get(units));// * (negative ? -1L : 1L);
   }
 
   private static final Map<java.lang.String, TimeUnit> timeUnitMap = new HashMap<java.lang.String, TimeUnit>(){{

--- a/src/test/com/scalyr/api/tests/KnobTest.java
+++ b/src/test/com/scalyr/api/tests/KnobTest.java
@@ -548,22 +548,27 @@ public class KnobTest extends KnobTestBase {
     // Part 2: Testing functionality of knobs made from a config file
     //--------------------------------------------------------------------------------
 
-    //Config file simulation
+    // Config file simulation
     expectRequest(
         "getFile",
         "{'token': 'dummyToken', 'path': '/foo.txt'}",
         "{'status': 'success', 'path': '/foo.txt', 'version': 1, 'createDate': 1000, 'modDate': 2000," +
-            "'content': '{\\'time1\\': \\' 2     mins\\', \\'time2\\': \\'415nanos\\', \\'invalidTime1\\': \\'3d2 secs\\'," +
-            "\\'invalidTime2\\': \\'32 seuycs\\', \\'invalidTime3\\': \\'3d2secs\\', \\'negativeInt\\': \\'-2sec\\'}'}");
+            "'content': '{\\'time1\\': \\' 2     mins\\', \\'time2\\': \\'415nanos\\', \\'negativeKnob\\': \\'-2sec\\'," +
+            "\\'positiveKnob\\': \\'+2sec\\', \\'invalidTime1\\': \\'3d2 secs\\', \\'invalidTime2\\': \\'32 seuycs\\'," +
+            "\\'invalidTime3\\': \\'3d2secs\\', \\'invalidSign1\\': \\'--2min\\', \\'invalidSign2\\': \\'2+ sec\\'," +
+            "\\'invalidSign3\\': \\'-+ 3 days\\', \\'invalidSign4\\': \\'3+3days\\'}'}");
 
     ConfigurationFile paramFile = factory.getFile("/foo.txt");
 
-    //Test negative values
+    // Test signed values
 
-    Knob.Duration negativeInt = new Knob.Duration("negativeInt", 1L, TimeUnit.SECONDS, paramFile);
-    assertEquals((Long) (-2000L), negativeInt.millis());
+    Knob.Duration negativeKnob = new Knob.Duration("negativeKnob", 1L, TimeUnit.SECONDS, paramFile);
+    assertEquals((Long) (-2000L), negativeKnob.millis());
 
-    //Random tests on 2min knob
+    Knob.Duration positiveKnob = new Knob.Duration("positiveKnob", 1L, TimeUnit.SECONDS, paramFile);
+    assertEquals((Long) 2000L, positiveKnob.millis());
+
+    // Random tests on 2min knob
 
     Knob.Duration value2min = new Knob.Duration("time1", 1L, TimeUnit.SECONDS, paramFile);
 
@@ -571,7 +576,7 @@ public class KnobTest extends KnobTestBase {
     assertEquals((Long) 120L,          value2min.seconds());
     assertEquals(120000000000L, value2min.get().toNanos());
 
-    //ALL possible tests on 3day knob
+    // ALL possible tests on 3day knob
 
     Knob.Duration value3days = new Knob.Duration("time3", 3L, TimeUnit.DAYS, paramFile);
 
@@ -588,13 +593,13 @@ public class KnobTest extends KnobTestBase {
     assertEquals(72L,                 value3days.get().toHours());
     assertEquals(3L,                  value3days.get().toDays());
 
-    //Testing default value on knob with no config
+    // Testing default value on knob with no config
 
     Knob.Duration unconfiguredKnob = new Knob.Duration("nonexistent label", 1L, TimeUnit.DAYS, paramFile);
     assertEquals((Long) 24L, unconfiguredKnob.hours());
     assertEquals(1L, unconfiguredKnob.get().toDays());
 
-    //Exception testing
+    // Exception testing
 
     Knob.Duration invalidKnob1 = new Knob.Duration("invalidTime1", 3L, TimeUnit.DAYS, paramFile);
     fails(invalidKnob1::hours, RuntimeException.class);
@@ -604,6 +609,18 @@ public class KnobTest extends KnobTestBase {
 
     Knob.Duration invalidKnob3 = new Knob.Duration("invalidTime3", 3L, TimeUnit.DAYS, paramFile);
     fails(invalidKnob3::hours, RuntimeException.class);
+
+    Knob.Duration invalidSign1 = new Knob.Duration("invalidSign1", 3L, TimeUnit.DAYS, paramFile);
+    fails(invalidSign1::hours, RuntimeException.class);
+
+    Knob.Duration invalidSign2 = new Knob.Duration("invalidSign2", 3L, TimeUnit.DAYS, paramFile);
+    fails(invalidSign2::get, RuntimeException.class);
+
+    Knob.Duration invalidSign3 = new Knob.Duration("invalidSign3", 3L, TimeUnit.DAYS, paramFile);
+    fails(invalidSign3::hours, RuntimeException.class);
+
+    Knob.Duration invalidSign4 = new Knob.Duration("invalidSign4", 3L, TimeUnit.DAYS, paramFile);
+    fails(invalidSign4::minutes, RuntimeException.class);
   }
 
   @Test public void testGetLongGetIntWithSI() {

--- a/src/test/com/scalyr/api/tests/KnobTest.java
+++ b/src/test/com/scalyr/api/tests/KnobTest.java
@@ -554,9 +554,14 @@ public class KnobTest extends KnobTestBase {
         "{'token': 'dummyToken', 'path': '/foo.txt'}",
         "{'status': 'success', 'path': '/foo.txt', 'version': 1, 'createDate': 1000, 'modDate': 2000," +
             "'content': '{\\'time1\\': \\' 2     mins\\', \\'time2\\': \\'415nanos\\', \\'invalidTime1\\': \\'3d2 secs\\'," +
-            "\\'invalidTime2\\': \\'32 seuycs\\', \\'invalidTime3\\': \\'3d2secs\\'}'}");
+            "\\'invalidTime2\\': \\'32 seuycs\\', \\'invalidTime3\\': \\'3d2secs\\', \\'negativeInt\\': \\'-2sec\\'}'}");
 
     ConfigurationFile paramFile = factory.getFile("/foo.txt");
+
+    //Test negative values
+
+    Knob.Duration negativeInt = new Knob.Duration("negativeInt", 1L, TimeUnit.SECONDS, paramFile);
+    assertEquals((Long) (-2000L), negativeInt.millis());
 
     //Random tests on 2min knob
 


### PR DESCRIPTION
Was noticing that sometimes knobs have negative values, used as flags to indicate things like fallback behavior, so made `Knob.Duration` negative friendly. The `java.Duration` was already negative-friendly, just had to tell the Knob parser not to throw an exception on a +/- sign.