### PR TITLE
Change Duration Knob to function on Doubles

### DIFF
--- a/src/main/com/scalyr/api/Converter.java
+++ b/src/main/com/scalyr/api/Converter.java
@@ -226,7 +226,7 @@ public class Converter {
    * Parses a config string for a Duration Knob and returns its value in Nanoseconds.
    * See {@link com.scalyr.api.knobs.Knob.Duration} DurationKnob javadocs for usage/rules.
    */
-  public static Long parseNanos(Object value) {
+  public static Long parseNanos(Object value) throws NumberFormatException {
     if (value == null)            return null;
     if (value instanceof Integer) return (long)(int)(Integer)value;
     if (value instanceof Long)    return (Long)value;
@@ -254,7 +254,7 @@ public class Converter {
           if (c == '-' || c == '+') {
             if (seenNumber || seenSign) throw new RuntimeException(exceptionMessage);
             seenSign = true;
-          } else if (Character.isDigit(c)) {
+          } else if (Character.isDigit(c) || c == '.') {
             seenNumber = true;
           } else if (!seenNumber) { // If we've hit a non-# character before getting any numbers
             throw new RuntimeException(exceptionMessage);
@@ -278,8 +278,8 @@ public class Converter {
     }
 
     // If no units were in the string, we interpret it as nanoseconds. Otherwise get and apply conversion from map.
-    return TimeUnit.NANOSECONDS.convert(java.lang.Long.parseLong(magnitude),
-              units.length() == 0 ? TimeUnit.NANOSECONDS : timeUnitMap.get(units));
+    return (long) (java.lang.Double.parseDouble(magnitude)
+            * TimeUnit.NANOSECONDS.convert(1, units.length() == 0 ? TimeUnit.NANOSECONDS : timeUnitMap.get(units)));
   }
 
   private static final Map<java.lang.String, TimeUnit> timeUnitMap = new HashMap<java.lang.String, TimeUnit>(){{

--- a/src/main/com/scalyr/api/knobs/Knob.java
+++ b/src/main/com/scalyr/api/knobs/Knob.java
@@ -487,29 +487,29 @@ public class Knob {
    *
    * METHODS TO GET VALUE:
    *
-   *  - We provide long-valued accessors that return commonly used units:
+   *  - We provide double-valued accessors that return commonly used units:
    *    .nanos(), .micros(), .millis(), .seconds(), .minutes(), .hours(), .days()
    *  - The standard Knob.get() method is also overridden to return a java.time.Duration object,
    *    which can be used with its native methods such as .toNanos() to get a Long value.
    *
    * EXAMPLE USAGE:
    *
-   *  // Assume that config file has {myLabel: "1day"}
-   *  Knob.Duration myKnob = new Knob.Duration("myLabel", 1L, TimeUnit.SECONDS, paramFile);
-   *  long hoursInADay = myKnob.hours(); //Will be 24 hours
+   *  // Assume that config file has {myLabel: "1.5hr"}
+   *  Knob.Duration myKnob = new Knob.Duration("myLabel", 1D, TimeUnit.SECONDS, paramFile);
+   *  double 90min = myKnob.minutes(); // Will be 90
    *
    */
   public static class Duration extends Knob {
 
-    public Duration(java.lang.String valueKey, java.lang.Long defaultValue, TimeUnit defaultTimeUnit, ConfigurationFile ... files) {
+    public Duration(java.lang.String valueKey, java.lang.Double defaultValue, TimeUnit defaultTimeUnit, ConfigurationFile ... files) {
       // We always store default value in Nanoseconds. If TimeUnit is null, assume defaultValue is in nanoseconds.
       super(valueKey, calculateDefaultTime(defaultValue, defaultTimeUnit), Converter::parseNanos, files);
     }
 
-    private static java.lang.Long calculateDefaultTime(java.lang.Long defaultValue, TimeUnit defaultTimeUnit) {
+    private static java.lang.Long calculateDefaultTime(java.lang.Double defaultValue, TimeUnit defaultTimeUnit) {
       if (defaultValue != null && defaultTimeUnit != null)
-        return TimeUnit.NANOSECONDS.convert(defaultValue, defaultTimeUnit);
-      else return defaultValue;
+        return (long) (defaultValue * TimeUnit.NANOSECONDS.convert(1, defaultTimeUnit));
+      else return defaultValue == null ? null : defaultValue.longValue();
     }
 
     //--------------------------------------------------------------------------------
@@ -538,18 +538,18 @@ public class Knob {
     // New Methods
     //--------------------------------------------------------------------------------
 
-    public java.lang.Long nanos()   { return convertToLongTime(TimeUnit.NANOSECONDS);  }
-    public java.lang.Long micros()  { return convertToLongTime(TimeUnit.MICROSECONDS); }
-    public java.lang.Long millis()  { return convertToLongTime(TimeUnit.MILLISECONDS); }
-    public java.lang.Long seconds() { return convertToLongTime(TimeUnit.SECONDS);      }
-    public java.lang.Long minutes() { return convertToLongTime(TimeUnit.MINUTES);      }
-    public java.lang.Long hours()   { return convertToLongTime(TimeUnit.HOURS);        }
-    public java.lang.Long days()    { return convertToLongTime(TimeUnit.DAYS);         }
+    public java.lang.Double nanos()   { return convertToDoubleTime(TimeUnit.NANOSECONDS);  }
+    public java.lang.Double micros()  { return convertToDoubleTime(TimeUnit.MICROSECONDS); }
+    public java.lang.Double millis()  { return convertToDoubleTime(TimeUnit.MILLISECONDS); }
+    public java.lang.Double seconds() { return convertToDoubleTime(TimeUnit.SECONDS);      }
+    public java.lang.Double minutes() { return convertToDoubleTime(TimeUnit.MINUTES);      }
+    public java.lang.Double hours()   { return convertToDoubleTime(TimeUnit.HOURS);        }
+    public java.lang.Double days()    { return convertToDoubleTime(TimeUnit.DAYS);         }
 
-    /** Converts Knob value to a Long in the desired units, and checks for null value. */
-    private java.lang.Long convertToLongTime(TimeUnit desiredUnits) {
+    /** Converts Knob value to a Double in the desired units, and checks for null value. */
+    private java.lang.Double convertToDoubleTime(TimeUnit desiredUnits) {
       java.lang.Long value = (java.lang.Long) super.getWithTimeout(null, false);
-      return value != null ? desiredUnits.convert(value, TimeUnit.NANOSECONDS) : null;
+      return value != null ? value.doubleValue() / TimeUnit.NANOSECONDS.convert(1, desiredUnits) : null;
     }
   }
 


### PR DESCRIPTION
As I've been doing the SI Cleanup, it's becoming evident that the fact that `Knob.Duration` loses accuracy in one direction (eg. calling `secs()` on a `200ms` knob will in fact return `0`), since it functions on `Long`s, could cause unexpected behavior in places. In the code sometimes people convert times from `ms` to `sec`, and so on. I think `Knob.Duration`, to truly be a "container" of a time quantity, should be reliable in either direction. So I changed it to function on Doubles. I'll go through the code base later and change all instances to work.