### PR TITLE
BACK-847 Ensure HTTP client input stream is always closed

### DIFF
--- a/src/main/com/scalyr/api/internal/ScalyrService.java
+++ b/src/main/com/scalyr/api/internal/ScalyrService.java
@@ -358,12 +358,8 @@ public abstract class ScalyrService {
 
         byte[] rawResponse;
 
-        try {
-          InputStream input = httpClient.getInputStream();
-          rawResponse = readEntireStream(input);
-        } finally {
-          httpClient.finishedReadingResponse();
-        }
+        InputStream input = httpClient.getInputStream();
+        rawResponse = readEntireStream(input);
 
         // Log a random sample of server response times.
         Severity severity = Severity.fine;
@@ -414,6 +410,11 @@ public abstract class ScalyrService {
         }
 
       } finally {
+        if (httpClient != null) {
+          // ensure input stream is closed if client is created
+          InputStream input = httpClient.getInputStream();
+          httpClient.finishedReadingResponse();
+        }
         if (TuningConstants.serverInvocationTimeCounterSecs != null) {
           TuningConstants.serverInvocationTimeCounterSecs.increment((ScalyrUtil.currentTimeMillis() - startTimeMs) / 1000.0);
         }

--- a/src/main/com/scalyr/api/logs/EventAttributes.java
+++ b/src/main/com/scalyr/api/logs/EventAttributes.java
@@ -188,7 +188,7 @@ public class EventAttributes {
 
   /**
    * Copy all attributes from the given object to this object. In case of conflicts,
-   * attributes from objectToCopy are ignored.
+   * attributes from {@code source} are ignored.
    *
    * Return this object.
    */


### PR DESCRIPTION
If you create an HTTP client and fail to close its input stream, the JVM can leave the TCP connection in a `CLOSE_WAIT` state.

This moves the input stream `close` into a `finally` block to ensure it is closed.

There's more information in YouTrack ticket [BACK-847](https://scalyr.myjetbrains.com/youtrack/issue/BACK-847).