### PR TITLE
Support action on Knob failure and default value

### DIFF
--- a/src/main/com/scalyr/api/knobs/Knob.java
+++ b/src/main/com/scalyr/api/knobs/Knob.java
@@ -149,7 +149,7 @@ public class Knob {
   /**
    * Specify the action to take for a converter failure on a per Knob basis
    *
-   * e.g. {@code setDefaultOnConversionFailure((throwable, value) -> { logError(throwable, value); return true; });}
+   * e.g. {@code setOnConversionFailure((throwable, value) -> { logError(throwable, value); return true; });}
    *
    * @param action takes in a Throwable that caused the failure, the value that was trying to be converted, and
    *               returns a boolean of whether the default Knob value should be used
@@ -179,8 +179,13 @@ public class Knob {
       try {
         return converter.apply(obj);
       } catch (Throwable t) {
-        if      (onConversionFailure        != null && onConversionFailure.apply(t, obj)       ) return defaultValue;
-        else if (defaultOnConversionFailure != null && defaultOnConversionFailure.apply(t, obj)) return defaultValue;
+        if (onConversionFailure != null) {
+          if (onConversionFailure.apply(t, obj))
+            return defaultValue;
+        } else if (defaultOnConversionFailure != null) {
+          if (defaultOnConversionFailure.apply(t, obj))
+            return defaultValue;
+        }
 
         throw t;
       }

--- a/src/main/com/scalyr/api/knobs/Knob.java
+++ b/src/main/com/scalyr/api/knobs/Knob.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -124,6 +125,41 @@ public class Knob {
   }
 
   /**
+   * Called whenever converter fails to parse a value
+   */
+  private static BiFunction<Throwable, Object, java.lang.Boolean> defaultOnConversionFailure;
+
+  /**
+   * Specify the default action to take for a converter failure for all Knobs
+   *
+   * e.g. {@code setDefaultOnConversionFailure((throwable, value) -> { logError(throwable, value); return true; });}
+   *
+   * @param action takes in a Throwable that caused the failure, the value that was trying to be converted, and
+   *               returns a boolean of whether the default Knob value should be used
+   */
+  public static void setDefaultOnConversionFailure(BiFunction<Throwable, Object, java.lang.Boolean> action) {
+    defaultOnConversionFailure = action;
+  }
+
+  /**
+   * Called whenever {@link #converter} fails to parse a value
+   */
+  private BiFunction<Throwable, Object, java.lang.Boolean> onConversionFailure;
+
+  /**
+   * Specify the action to take for a converter failure on a per Knob basis
+   *
+   * e.g. {@code setDefaultOnConversionFailure((throwable, value) -> { logError(throwable, value); return true; });}
+   *
+   * @param action takes in a Throwable that caused the failure, the value that was trying to be converted, and
+   *               returns a boolean of whether the default Knob value should be used
+   */
+  public Knob setOnConversionFailure(BiFunction<Throwable, Object, java.lang.Boolean> action) {
+    this.onConversionFailure = action;
+    return this;
+  }
+
+  /**
    * @param key The key to look for (a fieldname of the top-level JSON object in the file), or null to always use defaultValue.
    * @param defaultValue Value to return from {@link #get()} if the file does not exist or does not
    *     contain the key.
@@ -139,7 +175,16 @@ public class Knob {
     }
     this.key = key;
     this.defaultValue = defaultValue;
-    this.converter = converter;
+    this.converter = converter == null ? null : (obj) -> {
+      try {
+        return converter.apply(obj);
+      } catch (Throwable t) {
+        if      (onConversionFailure        != null && onConversionFailure.apply(t, obj)       ) return defaultValue;
+        else if (defaultOnConversionFailure != null && defaultOnConversionFailure.apply(t, obj)) return defaultValue;
+
+        throw t;
+      }
+    };
   }
 
   public Knob(java.lang.String key, Object defaultValue, ConfigurationFile ... files) {

--- a/src/test/com/scalyr/api/tests/KnobTest.java
+++ b/src/test/com/scalyr/api/tests/KnobTest.java
@@ -40,6 +40,7 @@ import java.io.StringWriter;
 import java.util.HashSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -60,6 +61,8 @@ public class KnobTest extends KnobTestBase {
 
   @Before @Override public void setup() {
     super.setup();
+
+    Knob.setDefaultOnConversionFailure(null);
 
     paramDir = TestUtils.createTemporaryDirectory();
     paramFactory = ConfigurationFile.makeLocalFileFactory(paramDir, 100);
@@ -736,5 +739,35 @@ public class KnobTest extends KnobTestBase {
     ConfigurationFile paramFile = factory.getFile("/foo.txt");
     assertEquals((int) Knob.getInteger("test", 1, paramFile), 256000);
     assertEquals((long) Knob.getLong("test", 1L, paramFile), 256000L);
+  }
+
+  @Test public void testBadConversionAction() {
+    expectRequest(
+      "getFile",
+      "{'token': 'dummyToken', 'path': '/foo.txt'}",
+      "{'status': 'success', 'path': '/foo.txt', 'version': 1, 'createDate': 1000, 'modDate': 2000," +
+        "'content': '{\\'invalidSign4\\': \\'3+3days\\'}'}");
+
+    ConfigurationFile paramFile = factory.getFile("/foo.txt");
+
+    AtomicInteger calledDefault = new AtomicInteger();
+    Knob.setDefaultOnConversionFailure((t, o) -> { calledDefault.incrementAndGet(); return false; });
+
+    // misconfigured Knob so calls its defaultBadConversionAction but it still throws
+    Knob.Duration invalidSign4 = new Knob.Duration("invalidSign4", 3L, TimeUnit.DAYS, paramFile);
+    fails(() -> invalidSign4.get().toDays(), RuntimeException.class);
+    assertEquals(1, calledDefault.get());
+
+    // misconfigured Knob so calls its defaultBadConversionAction but now we return the default value
+    Knob.setDefaultOnConversionFailure((t, o) -> { calledDefault.incrementAndGet(); return true; });
+    assertEquals(3L, invalidSign4.get().toDays());
+    assertEquals(2 , calledDefault.get()        );
+
+    // misconfigured Knob so calls its badConversionAction and we return the default
+    AtomicInteger calledOverride = new AtomicInteger();
+    invalidSign4.setOnConversionFailure((t, o) -> { calledOverride.incrementAndGet(); return true; });
+    assertEquals(3L, invalidSign4.get().toDays());
+    assertEquals(2 , calledDefault.get()        );
+    assertEquals(1 , calledOverride.get()       );
   }
 }

--- a/src/test/com/scalyr/api/tests/KnobTest.java
+++ b/src/test/com/scalyr/api/tests/KnobTest.java
@@ -753,21 +753,25 @@ public class KnobTest extends KnobTestBase {
     AtomicInteger calledDefault = new AtomicInteger();
     Knob.setDefaultOnConversionFailure((t, o) -> { calledDefault.incrementAndGet(); return false; });
 
-    // misconfigured Knob so calls its defaultBadConversionAction but it still throws
+    // misconfigured Knob so calls its defaultOnConversionFailure but it still throws
     Knob.Duration invalidSign4 = new Knob.Duration("invalidSign4", 3L, TimeUnit.DAYS, paramFile);
     fails(() -> invalidSign4.get().toDays(), RuntimeException.class);
     assertEquals(1, calledDefault.get());
 
-    // misconfigured Knob so calls its defaultBadConversionAction but now we return the default value
+    // misconfigured Knob so calls its defaultOnConversionFailure but now we return the default value
     Knob.setDefaultOnConversionFailure((t, o) -> { calledDefault.incrementAndGet(); return true; });
     assertEquals(3L, invalidSign4.get().toDays());
     assertEquals(2 , calledDefault.get()        );
 
-    // misconfigured Knob so calls its badConversionAction and we return the default
+    // misconfigured Knob so calls its onConversionFailure and we return the default
     AtomicInteger calledOverride = new AtomicInteger();
     invalidSign4.setOnConversionFailure((t, o) -> { calledOverride.incrementAndGet(); return true; });
     assertEquals(3L, invalidSign4.get().toDays());
     assertEquals(2 , calledDefault.get()        );
     assertEquals(1 , calledOverride.get()       );
+
+    // misconfigured Knob so calls its onConversionFailure but we throw since we don't return the default
+    invalidSign4.setOnConversionFailure((t, o) -> { calledOverride.incrementAndGet(); return false; });
+    fails(() -> invalidSign4.get().toDays(), RuntimeException.class);
   }
 }


### PR DESCRIPTION
Whenever we setup the Knob configs we would then do:

```java
Knob.setDefaultFiles(defaultFiles);
Knob.setDefaultOnConversionFailure((throwable, value) -> { rateLimitedError(throwable); return true; });
```

@goldfrapp04 adding you as a reviewer, since you looked at #36 and I'm tagging @jjhart as author of the ticket.