### PR TITLE
Add new log with builder call chaining interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>19.0</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/com/scalyr/api/logs/EventBuilder.java
+++ b/src/main/com/scalyr/api/logs/EventBuilder.java
@@ -31,9 +31,6 @@ import java.util.stream.Collectors;
  */
 public final class EventBuilder {
 
-  /** Sink which does nothing, provided as convenience */
-  public static final BiConsumer<Severity, EventAttributes> SILENT_EVENT_SINK = (sev, attrs) -> {};
-
   /** Class to start the builder call chaining. */
   public static final class EventStart implements KeyValueLog {
 
@@ -52,7 +49,21 @@ public final class EventBuilder {
     // overrides
     //--------------------------------------------------------------------------------
 
-    @Override public KeyValueLog add(String key1, Object val1) { return new Builder(eventSink).add(key1, val1); }
+    @Override public KeyValueLog add(String key1, Object val1) {
+      return new Builder(eventSink).add(key1, val1);
+    }
+
+    @Override public KeyValueLog add(String key1, Object val1, String key2, Object val2) {
+      return new Builder(eventSink).add(key1, val1, key2, val2);
+    }
+
+    @Override public KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3) {
+      return new Builder(eventSink).add(key1, val1, key2, val2, key3, val3);
+    }
+
+    @Override public KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3, String key4, Object val4) {
+      return new Builder(eventSink).add(key1, val1, key2, val2, key3, val3, key4, val4);
+    }
 
     @Override public KeyValueLog add  (AnnotFn annotFn) { return new Builder(eventSink).add  (annotFn); }
     @Override public KeyValueLog union(AnnotFn annotFn) { return new Builder(eventSink).union(annotFn); }
@@ -86,6 +97,27 @@ public final class EventBuilder {
 
     @Override public KeyValueLog add(String key1, Object val1) {
       attrs.put(key1, val1);
+      return this;
+    }
+
+    @Override public KeyValueLog add(String key1, Object val1, String key2, Object val2) {
+      attrs.put(key1, val1);
+      attrs.put(key2, val2);
+      return this;
+    }
+
+    @Override public KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3) {
+      attrs.put(key1, val1);
+      attrs.put(key2, val2);
+      attrs.put(key3, val3);
+      return this;
+    }
+
+    @Override public KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3, String key4, Object val4) {
+      attrs.put(key1, val1);
+      attrs.put(key2, val2);
+      attrs.put(key3, val3);
+      attrs.put(key4, val4);
       return this;
     }
 

--- a/src/main/com/scalyr/api/logs/EventBuilder.java
+++ b/src/main/com/scalyr/api/logs/EventBuilder.java
@@ -24,8 +24,16 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 /**
- * This class is normally not used directly, but instead used by a `getLogger()` method which allows providing
- * a class-specific log instance.
+ * Contains implementations of {@link KeyValueLog} which allow key-value logging using builder call chaining.
+ *
+ * These classes are not normally used directly. Users will likely prefer using a factory method e.g. `getLogger`
+ * which returns instances of {@link EventStart}.
+ *
+ * <pre>
+ *   static KeyValueLog getLogger() {
+ *     return new EventStart(sink); // in most cases `sink` is a bi-consumer that is long lived in order to reduce object creation
+ *   }
+ * </pre>
  *
  * For example usage, see: {@link KeyValueLog}.
  */

--- a/src/main/com/scalyr/api/logs/EventBuilder.java
+++ b/src/main/com/scalyr/api/logs/EventBuilder.java
@@ -24,19 +24,10 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 /**
- * Contains implementations of {@link KeyValueLog} which allow key-value logging using builder call chaining.
+ * This class is normally not used directly, but instead used by a `getLogger()` method which allows providing
+ * a class-specific log instance.
  *
- * Example usage:
- *
- * <pre>
- *   // Emit an event at Severity.info
- *   EventStart log = new EventStart(scalyrSink)
- *     .add("tag"   , "foo")
- *     .add("subtag", "bar")
- *     .add("count" , 123  )
- *     .info();
- * </pre>
- *
+ * For example usage, see: {@link KeyValueLog}.
  */
 public final class EventBuilder {
 

--- a/src/main/com/scalyr/api/logs/EventBuilder.java
+++ b/src/main/com/scalyr/api/logs/EventBuilder.java
@@ -1,0 +1,169 @@
+/*
+ * Scalyr client library
+ * Copyright 2012 Scalyr, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.scalyr.api.logs;
+
+import com.google.common.base.Throwables;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+/**
+ * Contains implementations of {@link KeyValueLog} which allow key-value logging using builder call chaining.
+ *
+ * Example usage:
+ *
+ * <pre>
+ *   // Emit an event at Severity.info
+ *   EventStart log = new EventStart(scalyrSink)
+ *     .add("tag"   , "foo")
+ *     .add("subtag", "bar")
+ *     .add("count" , 123  )
+ *     .info();
+ * </pre>
+ *
+ */
+public final class EventBuilder {
+
+  /** Sink which does nothing, provided as convenience */
+  public static final BiConsumer<Severity, EventAttributes> SILENT_EVENT_SINK = (sev, attrs) -> {};
+
+  /** Class to start the builder call chaining. */
+  public static final class EventStart implements KeyValueLog {
+
+    /** Sink to emit events to */
+    final BiConsumer<Severity, EventAttributes> eventSink;
+
+    //--------------------------------------------------------------------------------
+    // ctors
+    //--------------------------------------------------------------------------------
+
+    public EventStart(BiConsumer<Severity, EventAttributes> eventSink) {
+      this.eventSink  = eventSink;
+    }
+
+    //--------------------------------------------------------------------------------
+    // overrides
+    //--------------------------------------------------------------------------------
+
+    @Override public KeyValueLog add(String key1, Object val1) { return new Builder(eventSink).add(key1, val1); }
+
+    @Override public KeyValueLog add  (AnnotFn annotFn) { return new Builder(eventSink).add  (annotFn); }
+    @Override public KeyValueLog union(AnnotFn annotFn) { return new Builder(eventSink).union(annotFn); }
+
+    @Override public KeyValueLog add  (String prefix, AnnotFn annotFn) { return new Builder(eventSink).add  (prefix, annotFn); }
+    @Override public KeyValueLog union(String prefix, AnnotFn annotFn) { return new Builder(eventSink).union(prefix, annotFn); }
+
+    @Override public KeyValueLog incl(Annot annot) { return new Builder(eventSink).incl(annot); }
+    @Override public KeyValueLog err (Throwable e) { return new Builder(eventSink).err (e)    ; }
+
+    @Override public void emit(Severity sev) { new Builder(eventSink).emit(sev); }
+  } // EventStart
+
+  /** The normal builder. It accumulates attributes and emits an event to the sink instance. */
+  public static final class Builder implements KeyValueLog {
+    final EventAttributes attrs = new EventAttributes();
+
+    final BiConsumer<Severity, EventAttributes> eventSink;
+
+    //--------------------------------------------------------------------------------
+    // ctors
+    //--------------------------------------------------------------------------------
+
+    public Builder(BiConsumer<Severity, EventAttributes> eventSink) {
+      this.eventSink = eventSink;
+    }
+
+    //--------------------------------------------------------------------------------
+    // overrides
+    //--------------------------------------------------------------------------------
+
+    @Override public KeyValueLog add(String key1, Object val1) {
+      attrs.put(key1, val1);
+      return this;
+    }
+
+    @Override public KeyValueLog add(AnnotFn annotFn) {
+      annotFn.apply(attrs);
+      return this;
+    }
+
+    @Override public KeyValueLog union(AnnotFn annotFn) {
+      final EventAttributes ea = annotFn.apply(new EventAttributes());
+      attrs.underwriteFrom(ea);
+      return this;
+    }
+
+    @Override public KeyValueLog add(String prefix, AnnotFn annotFn) {
+      final EventAttributes ea = annotFn.apply(new EventAttributes());
+      for (Map.Entry<String, Object> entry : ea.getEntries()) {
+        attrs.put(prefix + entry.getKey(), entry.getValue());
+      }
+      return this;
+    }
+
+    @Override public KeyValueLog union(String prefix, AnnotFn annotFn) {
+      final EventAttributes ea = annotFn.apply(new EventAttributes());
+      for (Map.Entry<String, Object> entry : ea.getEntries()) {
+        attrs.putIfAbsent(prefix + entry.getKey(), entry.getValue());
+      }
+      return this;
+    }
+
+    @Override public KeyValueLog incl(Annot annot) {
+      annot.annotFn().apply(attrs);
+      return this;
+    }
+
+    @Override public KeyValueLog err(Throwable e) {
+      annot(attrs, e);
+      return this;
+    }
+
+    /** Write attribute pairs to logger and monitor sink. */
+    @Override public void emit(Severity sev) {
+      eventSink.accept(sev, attrs);
+    }
+  } // EventBuilder
+
+  //--------------------------------------------------------------------------------
+  // public statics
+  //--------------------------------------------------------------------------------
+
+  /**
+   * @param attrs the attributes to flatten
+   * @return construct a space-separated string of `key=value` from the key-value pair(s) in `attrs`
+   */
+  public static String flatten(EventAttributes attrs) {
+    return attrs.getEntries().stream()
+      .map(e -> String.join("=", e.getKey(), "" + e.getValue()))  // a=1
+      .collect(Collectors.joining(" "));  // a=1 b=2 ...
+  }
+
+  /**
+   * @param ea the event attributes to annotate
+   * @param e the throwable to annotate with
+   * @return `ea` annotated with the `errorMessage`, `errorClass`, and `stackTrace` of `e`
+   */
+  public static EventAttributes annot(EventAttributes ea, Throwable e) {
+    return ea
+      .put("errorMessage", e.getMessage())
+      .put("errorClass", e.getClass().getSimpleName())
+      .put("stackTrace", Throwables.getStackTraceAsString(e));
+  }
+}

--- a/src/main/com/scalyr/api/logs/KeyValueLog.java
+++ b/src/main/com/scalyr/api/logs/KeyValueLog.java
@@ -92,18 +92,18 @@ public interface KeyValueLog {
   //--------------------------------------------------------------------------------
 
   /**
-   * Used for generalized logging by {@link #incl}, this does not allow called-by tracking.
-   * Prefer functional interface via {@link #add(AnnotFn)}, e.g. `.add(stats::annot)`, to this where possible.
+   * A functional log interface. Use this IN FAVOR OF the class-based interface.
+   * It allows called-by tracking. Example use: `.add(stats::annot)`.
+   */
+  interface AnnotFn extends Function<EventAttributes, EventAttributes> {}
+
+  /**
+   * A class-based log interface. Use this when it is not possible to use the functional interface.
+   * It does not allow called-by tracking. Example use: `.incl(obj)`.
    */
   interface Annot {
     AnnotFn annotFn();
   }
-
-  /**
-   * A simple method contract that supports called-by tracking and requires no explicit `implements`
-   * on class def.
-   */
-  interface AnnotFn extends Function<EventAttributes, EventAttributes> {}
 
   interface RateLimiter {
     boolean tryAcquire();

--- a/src/main/com/scalyr/api/logs/KeyValueLog.java
+++ b/src/main/com/scalyr/api/logs/KeyValueLog.java
@@ -22,19 +22,13 @@ public interface KeyValueLog {
   KeyValueLog add(String key1, Object val1);
 
   /** Add two key/value pairs to the event attributes for the next log event. */
-  default KeyValueLog add(String key1, Object val1, String key2, Object val2) {
-    return add(key1, val1).add(key2, val2);
-  }
+  KeyValueLog add(String key1, Object val1, String key2, Object val2);
 
   /** Add three key/value pairs to the event attributes for the next log event. */
-  default KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3) {
-    return add(key1, val1).add(key2, val2).add(key3, val3);
-  }
+  KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3);
 
   /** Add four key/value pairs to the event attributes for the next log event. */
-  default KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3, String key4, Object val4) {
-    return add(key1, val1).add(key2, val2).add(key3, val3).add(key4, val4);
-  }
+  KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3, String key4, Object val4);
 
   //--------------------------------------------------------------------------------
   // annotations
@@ -66,13 +60,13 @@ public interface KeyValueLog {
   void emit(Severity sev);
 
   /** Write a log event at `debug` severity using the collected event attributes. */
-  default void debug() { emit(Severity.fine);};
+  default void debug() { emit(Severity.fine); };
 
   /** Write a log event at `info` severity using the collected event attributes. */
-  default void info() { emit(Severity.info);};
+  default void info() { emit(Severity.info); };
 
   /** Write a log event at `warn` severity using the collected event attributes. */
-  default void warn() { emit(Severity.warning);};
+  default void warn() { emit(Severity.warning); };
 
   /** Write a log event at `error` severity using the collected event attributes. */
   default void error() { emit(Severity.error); };

--- a/src/main/com/scalyr/api/logs/KeyValueLog.java
+++ b/src/main/com/scalyr/api/logs/KeyValueLog.java
@@ -15,11 +15,30 @@ import java.util.function.*;
 public interface KeyValueLog {
 
   //--------------------------------------------------------------------------------
-  // abstract methods
+  // key-value adders
   //--------------------------------------------------------------------------------
 
   /** Add one key/value pair to the event attributes for the next log event. */
   KeyValueLog add(String key1, Object val1);
+
+  /** Add two key/value pairs to the event attributes for the next log event. */
+  default KeyValueLog add(String key1, Object val1, String key2, Object val2) {
+    return add(key1, val1).add(key2, val2);
+  }
+
+  /** Add three key/value pairs to the event attributes for the next log event. */
+  default KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3) {
+    return add(key1, val1).add(key2, val2).add(key3, val3);
+  }
+
+  /** Add four key/value pairs to the event attributes for the next log event. */
+  default KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3, String key4, Object val4) {
+    return add(key1, val1).add(key2, val2).add(key3, val3).add(key4, val4);
+  }
+
+  //--------------------------------------------------------------------------------
+  // annotations
+  //--------------------------------------------------------------------------------
 
   /** Add key/value pairs returned by `annotFn` to the event attributes. */
   KeyValueLog add(AnnotFn annotFn);
@@ -39,34 +58,12 @@ public interface KeyValueLog {
   /** Add exception information and stack trace key/value pairs to the event attributes. */
   KeyValueLog err(Throwable e);
 
+  //--------------------------------------------------------------------------------
+  // emitters
+  //--------------------------------------------------------------------------------
+
   /** Write a log event at `error` severity using the collected event attributes. */
   void emit(Severity sev);
-
-  //--------------------------------------------------------------------------------
-  // defaults
-  //--------------------------------------------------------------------------------
-
-  /** Evaluate rate-limiter and call log function if rate limiter returns `true`. */
-  default void limit(RateLimiter limiter, Runnable logFn) {
-    if (limiter.tryAcquire()) {
-      logFn.run();
-    }
-  }
-
-  /** Add two key/value pairs to the event attributes for the next log event. */
-  default KeyValueLog add(String key1, Object val1, String key2, Object val2) {
-    return add(key1, val1).add(key2, val2);
-  }
-
-  /** Add three key/value pairs to the event attributes for the next log event. */
-  default KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3) {
-    return add(key1, val1).add(key2, val2).add(key3, val3);
-  }
-
-  /** Add four key/value pairs to the event attributes for the next log event. */
-  default KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3, String key4, Object val4) {
-    return add(key1, val1).add(key2, val2).add(key3, val3).add(key4, val4);
-  }
 
   /** Write a log event at `debug` severity using the collected event attributes. */
   default void debug() { emit(Severity.fine);};
@@ -86,6 +83,13 @@ public interface KeyValueLog {
       warn();
     } else {
       error();
+    }
+  }
+
+  /** Evaluate rate-limiter and call log function if rate limiter returns `true`. */
+  default void limit(RateLimiter limiter, Runnable logFn) {
+    if (limiter.tryAcquire()) {
+      logFn.run();
     }
   }
 

--- a/src/main/com/scalyr/api/logs/KeyValueLog.java
+++ b/src/main/com/scalyr/api/logs/KeyValueLog.java
@@ -1,0 +1,113 @@
+package com.scalyr.api.logs;
+
+import java.util.function.*;
+
+/**
+ * An interface for key-value logging using builder call chaining. Example calls:
+ *
+ * <pre>
+ *   log.add("cmd", "send", "details", "Sent batch", "elapsedMs", elapsedMs).add(batch::annot).info();
+ *   log.add("cmd", "send", "details", "Call failed").err(e).error();
+ *   log.add("cmd", "send", "details", "Network error").err(e).carp(warnLimit);
+ *   log.limit(statsLimit, () -> log.add("cmd", "send", "details", "Stats").add(stats::annot).info());
+ * </pre>
+ */
+public interface KeyValueLog {
+
+  //--------------------------------------------------------------------------------
+  // abstract methods
+  //--------------------------------------------------------------------------------
+
+  /** Add one key/value pair to the event attributes for the next log event. */
+  KeyValueLog add(String key1, Object val1);
+
+  /** Add key/value pairs returned by `annotFn` to the event attributes. */
+  KeyValueLog add(AnnotFn annotFn);
+
+  /** Add key/value pairs (preserving existing key/values w/ matching keys) returned by `annotFn` to the event attributes. */
+  KeyValueLog union(AnnotFn annotFn);
+
+  /** Add key/value pairs returned by `annotFn` and prefix keys w/ `prefix`. */
+  KeyValueLog add(String prefix, AnnotFn annotFn);
+
+  /** Add key/value pairs (preserving existing key/values w/ matching keys) returned by `annotFn` and prefix keys w/ `prefix`. */
+  KeyValueLog union(String prefix, AnnotFn annotFn);
+
+  /** Add key/value pairs returned by `annot` implementation. */
+  KeyValueLog incl(Annot annot);
+
+  /** Add exception information and stack trace key/value pairs to the event attributes. */
+  KeyValueLog err(Throwable e);
+
+  /** Write a log event at `error` severity using the collected event attributes. */
+  void emit(Severity sev);
+
+  //--------------------------------------------------------------------------------
+  // defaults
+  //--------------------------------------------------------------------------------
+
+  /** Evaluate rate-limiter and call log function if rate limiter returns `true`. */
+  default void limit(RateLimiter limiter, Runnable logFn) {
+    if (limiter.tryAcquire()) {
+      logFn.run();
+    }
+  }
+
+  /** Add two key/value pairs to the event attributes for the next log event. */
+  default KeyValueLog add(String key1, Object val1, String key2, Object val2) {
+    return add(key1, val1).add(key2, val2);
+  }
+
+  /** Add three key/value pairs to the event attributes for the next log event. */
+  default KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3) {
+    return add(key1, val1).add(key2, val2).add(key3, val3);
+  }
+
+  /** Add four key/value pairs to the event attributes for the next log event. */
+  default KeyValueLog add(String key1, Object val1, String key2, Object val2, String key3, Object val3, String key4, Object val4) {
+    return add(key1, val1).add(key2, val2).add(key3, val3).add(key4, val4);
+  }
+
+  /** Write a log event at `debug` severity using the collected event attributes. */
+  default void debug() { emit(Severity.fine);};
+
+  /** Write a log event at `info` severity using the collected event attributes. */
+  default void info() { emit(Severity.info);};
+
+  /** Write a log event at `warn` severity using the collected event attributes. */
+  default void warn() { emit(Severity.warning);};
+
+  /** Write a log event at `error` severity using the collected event attributes. */
+  default void error() { emit(Severity.error); };
+
+  /** Call `warn` if limit function allows, otherwise call `error`. */
+  default void carp(RateLimiter limiter) {
+    if (limiter.tryAcquire()) {
+      warn();
+    } else {
+      error();
+    }
+  }
+
+  //--------------------------------------------------------------------------------
+  // interfaces
+  //--------------------------------------------------------------------------------
+
+  /**
+   * Used for generalized logging by {@link #incl}, this does not allow called-by tracking.
+   * Prefer functional interface via {@link #add(AnnotFn)}, e.g. `.add(stats::annot)`, to this where possible.
+   */
+  interface Annot {
+    AnnotFn annotFn();
+  }
+
+  /**
+   * A simple method contract that supports called-by tracking and requires no explicit `implements`
+   * on class def.
+   */
+  interface AnnotFn extends Function<EventAttributes, EventAttributes> {}
+
+  interface RateLimiter {
+    boolean tryAcquire();
+  }
+}


### PR DESCRIPTION
- Converts RateLimiter into an interface so users can supply their own implementation
- Some minor formatting to condense groups of one-line methods
- Removes forked event and flattened events sink and leaves that up to the user
- Take advantage of `defaults` so users don't have to implement the various "add N-key-value pairs" methods and the various logging methods for different severities.

FYI I took your comment of being "too kind" to heart and got rid of the dual logging.